### PR TITLE
Fixed exit command

### DIFF
--- a/Server/src/main/java/org/openas2/Session.java
+++ b/Server/src/main/java/org/openas2/Session.java
@@ -1,16 +1,16 @@
 package org.openas2;
 
-import org.openas2.app.OpenAS2Server;
+import java.util.Map;
+
 import org.openas2.cert.CertificateFactory;
 import org.openas2.partner.PartnershipFactory;
 import org.openas2.processor.Processor;
-
-import java.util.Map;
 
 
 /**
  * The <code>Session</code> interface provides configuration and resource information, and a means for
  * components to access the functionality of other components.
+ * The <code>Session</code> has its own lifecycle controlled by two methods {@link #start()} and {@link #close()}.
  *
  * @author Aaron Silinskas
  * @see Component
@@ -21,6 +21,20 @@ import java.util.Map;
 public interface Session {
 
     String DEFAULT_CONTENT_TRANSFER_ENCODING = "binary";
+
+    /**
+     * Lifecycle control method.
+     *
+     * @throws Exception
+     */
+    void start() throws Exception;
+
+    /**
+     * Lifecycle control method.
+     *
+     * @throws Exception
+     */
+    void stop() throws Exception;
 
     /**
      * Short-cut method to retrieve a certificate factory.
@@ -74,9 +88,5 @@ public interface Session {
     String getAppVersion();
 
     String getAppTitle();
-    
-    OpenAS2Server getServer();
-
-	void setServer(OpenAS2Server server);
 
 }

--- a/Server/src/main/java/org/openas2/XMLSession.java
+++ b/Server/src/main/java/org/openas2/XMLSession.java
@@ -18,7 +18,6 @@ import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
 
-import org.openas2.app.OpenAS2Server;
 import org.openas2.cert.CertificateFactory;
 import org.openas2.cmd.CommandManager;
 import org.openas2.cmd.CommandRegistry;
@@ -56,10 +55,8 @@ public class XMLSession extends BaseSession {
 
     private CommandRegistry commandRegistry;
     private CommandManager cmdManager = new CommandManager();
-    
-    private OpenAS2Server server;
 
-	private String VERSION;
+    private String VERSION;
     private String TITLE;
 
     public XMLSession(String configAbsPath) throws OpenAS2Exception,
@@ -76,16 +73,6 @@ public class XMLSession extends BaseSession {
         // scheduler should be initializer after all modules
         addSchedulerComponent();
     }
-
-    public OpenAS2Server getServer()
-	{
-		return server;
-	}
-
-	public void setServer(OpenAS2Server server)
-	{
-		this.server = server;
-	}
 
     private void addSchedulerComponent() throws OpenAS2Exception
     {

--- a/Server/src/main/java/org/openas2/cmd/processor/SocketCommandProcessor.java
+++ b/Server/src/main/java/org/openas2/cmd/processor/SocketCommandProcessor.java
@@ -135,7 +135,7 @@ public class SocketCommandProcessor extends BaseCommandProcessor {
 
                     if (commandName.equals(StreamCommandProcessor.EXIT_COMMAND))
                     {
-                        terminate();
+                        getSession().stop();
                     } else
                     {
                         List<String> params = new ArrayList<String>();
@@ -202,6 +202,5 @@ public class SocketCommandProcessor extends BaseCommandProcessor {
     {
         IOUtils.closeQuietly(sslserversocket);  // closes remote session
         super.destroy();
-
     }
 }

--- a/Server/src/main/java/org/openas2/cmd/processor/StreamCommandProcessor.java
+++ b/Server/src/main/java/org/openas2/cmd/processor/StreamCommandProcessor.java
@@ -146,7 +146,7 @@ public class StreamCommandProcessor extends BaseCommandProcessor {
     @Override
     public void destroy() throws Exception
     {
-        IOUtils.closeQuietly(reader); // stops terminal
+        IOUtils.closeQuietly(System.in);
         super.destroy();
     }
 }

--- a/Server/src/main/java/org/openas2/processor/DefaultProcessor.java
+++ b/Server/src/main/java/org/openas2/processor/DefaultProcessor.java
@@ -13,8 +13,8 @@ import org.openas2.OpenAS2Exception;
 import org.openas2.message.Message;
 
 public class DefaultProcessor extends BaseComponent implements Processor {
+    private static final Log LOGGER = LogFactory.getLog(DefaultProcessor.class.getSimpleName());
     private List<ProcessorModule> modules = new ArrayList<ProcessorModule>();
-    private Log logger = LogFactory.getLog(DefaultProcessor.class.getSimpleName());
 
     public List<ProcessorModule> getActiveModules()
     {
@@ -48,9 +48,9 @@ public class DefaultProcessor extends BaseComponent implements Processor {
         ProcessorException pex = null;
         boolean moduleFound = false;
 
-        if (logger.isDebugEnabled())
+        if (LOGGER.isDebugEnabled())
         {
-            logger.debug("Processor searching for module handler for action: " + action);
+            LOGGER.debug("Processor searching for module handler for action: " + action);
         }
 
         while (moduleIt.hasNext())
@@ -84,7 +84,7 @@ public class DefaultProcessor extends BaseComponent implements Processor {
                 return;
             }
             msg.setLogMsg("No handler found for action: " + action);
-            logger.error(msg);
+            LOGGER.error(msg);
             throw new NoModuleException(action, msg, options);
         }
     }
@@ -98,14 +98,14 @@ public class DefaultProcessor extends BaseComponent implements Processor {
             try
             {
                 ((ActiveModule) processorModule).start();
-                logger.info(ClassUtils.getSimpleName(processorModule.getClass()) + " started.");
+                LOGGER.info(ClassUtils.getSimpleName(processorModule.getClass()) + " started.");
             } catch (OpenAS2Exception e)
             {
                 e.terminate();
                 throw e;
             }
         }
-        logger.info(activeModules.size() + " active module(s) started.");
+        LOGGER.info(activeModules.size() + " active module(s) started.");
     }
 
     public void stopActiveModules()
@@ -116,15 +116,23 @@ public class DefaultProcessor extends BaseComponent implements Processor {
         {
             try
             {
-                ((ActiveModule) processorModule).stop();
-                logger.info(ClassUtils.getSimpleName(processorModule.getClass()) + " stopped.");
+                if (processorModule instanceof ActiveModule)
+                {
+                    ActiveModule activeModule = ActiveModule.class.cast(processorModule);
+                    if (activeModule.isRunning())
+                    {
+                        activeModule.stop();
+                        LOGGER.info(ClassUtils.getSimpleName(processorModule.getClass()) + " stopped.");
+                    }
+                }
+
             } catch (OpenAS2Exception e)
             {
                 e.terminate();
             }
         }
 
-        logger.info(activeModules.size() + " active module(s) stopped.");
+        LOGGER.info(activeModules.size() + " active module(s) stopped.");
     }
 
     @Override

--- a/Server/src/main/java/org/openas2/processor/msgtracking/EmbeddedDBHandler.java
+++ b/Server/src/main/java/org/openas2/processor/msgtracking/EmbeddedDBHandler.java
@@ -16,8 +16,8 @@ class EmbeddedDBHandler extends DbTrackingModule implements IDBHandler {
 
     @Nullable
     private JdbcConnectionPool cp = null;
-    
-	Server server = null;
+
+    private Server server = null;
 
     private String connectString = "jdbc:h2:file:DB/openas2";
 
@@ -61,8 +61,8 @@ class EmbeddedDBHandler extends DbTrackingModule implements IDBHandler {
 			// Stopping the TCP server will stop the database so only do one of them
 			if (server != null)
 			{
-				server.shutdown();
-			}
+                server.stop();
+            }
 			else
 			{
 					try

--- a/Server/src/main/java/org/openas2/schedule/SchedulerComponent.java
+++ b/Server/src/main/java/org/openas2/schedule/SchedulerComponent.java
@@ -61,6 +61,7 @@ public class SchedulerComponent extends BaseComponent {
     public void destroy() throws Exception
     {
         //graceful shutdown
+        executorService.shutdown();
         executorService.awaitTermination(3, TimeUnit.SECONDS);
         executorService.shutdownNow();
     }


### PR DESCRIPTION
H2 server thread was still running event after  org.h2.tools.Server#shutdown that prevented server from shutdown. org.h2.tools.Server#shutdown is internal API from H2. Instead org.h2.tools.Server#stop should be used.