### PR TITLE
Add Sentry logger

### DIFF
--- a/Server/pom.xml
+++ b/Server/pom.xml
@@ -155,5 +155,10 @@
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
         </dependency>
+        <dependency>
+            <groupId>io.sentry</groupId>
+            <artifactId>sentry</artifactId>
+            <version>1.2.2</version>
+        </dependency>
     </dependencies>
 </project>

--- a/Server/src/main/java/org/openas2/logging/SentryLogger.java
+++ b/Server/src/main/java/org/openas2/logging/SentryLogger.java
@@ -1,0 +1,31 @@
+package org.openas2.logging;
+
+import java.util.Map;
+
+import org.openas2.OpenAS2Exception;
+import org.openas2.Session;
+import org.openas2.message.Message;
+import io.sentry.Sentry;
+
+
+public class SentryLogger extends BaseLogger {
+
+    public static final String SENTRY_DSN = "dsn";
+
+    public void init(Session session, Map<String, String> parameters) throws OpenAS2Exception {
+        super.init(session, parameters);
+
+        Sentry.init(getParameter(SENTRY_DSN, true));
+    }
+
+    protected String getShowDefaults() {
+        return VALUE_SHOW_ALL;
+    }
+
+    public void doLog(Level level, String msgText, Message as2Msg) {
+    }
+
+    protected void doLog(OpenAS2Exception exception, boolean terminated) {
+        Sentry.capture(exception);
+    }
+}


### PR DESCRIPTION
This change adds basic support for configuring Sentry as error tracker. ([https://sentry.io](https://sentry.io))

Configuration is straightforward, simply add following to config.xml:
```
<logger classname="org.openas2.logging.SentryLogger"
	dsn="SENTRY DSN" />
```