### PR TITLE
Allow negative TZ offsets.

### DIFF
--- a/Server/src/test/java/org/openas2/message/AS2MessageMDNTest.java
+++ b/Server/src/test/java/org/openas2/message/AS2MessageMDNTest.java
@@ -35,6 +35,6 @@ public class AS2MessageMDNTest {
     public void shouldGenerateMessageId() throws Exception
     {
         String messageId = new AS2MessageMDN(message, false).generateMessageID();
-        assertThat("Check " + messageId, messageId.matches("^OPENAS2-[0-9]{14}\\+[0-9]{4}-[0-9]{4}@senderId_receiverId"), is(true));
+        assertThat("Check " + messageId, messageId.matches("^OPENAS2-[0-9]{14}[-+][0-9]{4}-[0-9]{4}@senderId_receiverId"), is(true));
     }
 }


### PR DESCRIPTION
As originally coded, this test will only pass with timezone offsets that begin with `+`.