### PR TITLE
Allow custom ID pattern for MDN messages sent to partner

### DIFF
--- a/Server/src/main/java/org/openas2/message/AS2MessageMDN.java
+++ b/Server/src/main/java/org/openas2/message/AS2MessageMDN.java
@@ -34,7 +34,7 @@ public class AS2MessageMDN extends BaseMessageMDN {
     @Override
     public String generateMessageID() throws InvalidParameterException
     {
-        return org.openas2.util.AS2Util.generateMessageID(getMessage());
+        return org.openas2.util.AS2Util.generateMDNMessageID(getMessage());
     }
 
 

--- a/Server/src/main/java/org/openas2/partner/AS2Partnership.java
+++ b/Server/src/main/java/org/openas2/partner/AS2Partnership.java
@@ -9,6 +9,7 @@ public interface AS2Partnership {
 	public static final String PA_AS2_MDN_OPTIONS = "as2_mdn_options"; // Requested options for returned MDN
 	public static final String PA_AS2_RECEIPT_OPTION = "as2_receipt_option"; // URL destination for an async MDN
 	public static final String PA_MESSAGEID = "messageid";  // format to use for message-id if not default
+	public static final String PA_MDN_MESSAGEID = "mdn_messageid";  // format to use for MDN message-id if not default
 	public static final String PA_RESEND_MAX_RETRIES = "resend_max_retries";  // format to use for message-id if not default
 	public static final String PA_CUSTOM_MIME_HEADERS = "custom_mime_headers"; // list of nme/value pairs for setting custom mime headers
 	public static final String PA_ADD_CUSTOM_MIME_HEADERS_TO_HTTP = "add_custom_mime_headers_to_http"; // Add the custom mime headers (if any) to HTTP header if "true"

--- a/Server/src/main/java/org/openas2/util/AS2Util.java
+++ b/Server/src/main/java/org/openas2/util/AS2Util.java
@@ -66,14 +66,17 @@ public class AS2Util {
 
         return ch;
     }
-    
+
+    private static CompositeParameters getCompositeParams(Message msg) {
+    	return new CompositeParameters(false).
+				add("date", new DateParameters()).
+				add("msg", new MessageParameters(msg)).
+				add("rand", new RandomParameters());
+	}
+
     public static String generateMessageID(Message msg) throws InvalidParameterException
     {
-    	CompositeParameters params = 
-    		new CompositeParameters(false).
-    			add("date", new DateParameters()).
-    			add("msg", new MessageParameters(msg)).
-    			add("rand", new RandomParameters());
+    	CompositeParameters params = getCompositeParams(msg);
         
     	String idFormat = msg.getPartnership().getAttribute(AS2Partnership.PA_MESSAGEID);
     	if (idFormat == null)
@@ -84,7 +87,21 @@ public class AS2Util {
   		return ParameterParser.parse(idFormat, params);
     }
 
+	public static String generateMDNMessageID(Message msg) throws InvalidParameterException
+	{
+		CompositeParameters params = getCompositeParams(msg);
 
+		String idFormat = msg.getPartnership().getAttribute(AS2Partnership.PA_MDN_MESSAGEID);
+		if (idFormat == null)
+		{
+			idFormat = Properties.getProperty("as2_mdn_message_id_format", null);
+			if (idFormat == null) {
+				// Fallback
+				return generateMessageID(msg);
+			}
+		}
+		return ParameterParser.parse(idFormat, params);
+	}
 
     public static MessageMDN createMDN(Session session, AS2Message msg, String mic,
             DispositionType disposition, String text) throws Exception {


### PR DESCRIPTION
The current configuration options allow user to create ID patterns that are valid for outgoing files but invalid for outgoing MDNs. An example of this behavior could be:

`as2_message_id_format="$msg.sender.name$-$msg.receiver.name$-$date.yyyyMMddHHmmss$-$msg.attributes.transactionID$"`

Such pattern works for outgoing files: The `transactionID` attribute (a token generated outside of OpenAS2) is taken right from the file name and no other UUID is used to keep things clear.
The outgoing MDNs also have their message ID but pattern above isn't valid here and `"null"` is used instead of the transaction ID. This would lead into duplicit message ID problems on the partner side, even if the `transactionID` was strictly unique.

This commit resolves this (even though uncommon) situation by adding an optional parameter to either global or partnership configuration. The user can set up a pattern that would be used for MDNs only.