### PR TITLE
Close sockets even on empty/invalid HTTP request

### DIFF
--- a/Server/src/main/java/org/openas2/processor/receiver/NetModule.java
+++ b/Server/src/main/java/org/openas2/processor/receiver/NetModule.java
@@ -198,14 +198,14 @@ public abstract class NetModule extends BaseReceiverModule {
         {
             Socket s = getSocket();
 
-            getOwner().getHandler().handle(getOwner(), s);
-
-            try
-            {
-                s.close();
-            } catch (IOException sce)
-            {
-                new WrappedException(sce).terminate();
+            try {
+                getOwner().getHandler().handle(getOwner(), s);
+            } finally {
+                try {
+                    s.close();
+                } catch (IOException sce) {
+                    new WrappedException(sce).terminate();
+                }
             }
         }
     }


### PR DESCRIPTION
This commit fixes a bug where a socket stays open if an empty or an invalid request has been received. This is a common situation with various TCP layer health check systems.