### PR TITLE
Message id encapsulation

### DIFF
--- a/Server/src/config/config.xml
+++ b/Server/src/config/config.xml
@@ -2,7 +2,7 @@
     <properties
         log_date_format="yyyy-MM-dd HH:mm:ss.SSS"
         sql_timestamp_format="yyyy-MM-dd HH:mm:ss.SSS"
-        as2_message_id_format="&lt;OPENAS2-$date.ddMMyyyyHHmmssZ$-$rand.UUID$@$msg.sender.as2_id$_$msg.receiver.as2_id$>"
+        as2_message_id_format="OPENAS2-$date.ddMMyyyyHHmmssZ$-$rand.UUID$@$msg.sender.as2_id$_$msg.receiver.as2_id$"
     />
 	<certificates classname="org.openas2.cert.PKCS12CertificateFactory"
 		filename="%home%/as2_certs.p12"

--- a/Server/src/main/java/org/openas2/cmd/processor/SocketCommandProcessor.java
+++ b/Server/src/main/java/org/openas2/cmd/processor/SocketCommandProcessor.java
@@ -14,7 +14,6 @@ import javax.net.ssl.SSLServerSocket;
 import javax.net.ssl.SSLServerSocketFactory;
 import javax.net.ssl.SSLSocket;
 
-import org.apache.commons.io.IOUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.openas2.OpenAS2Exception;
@@ -104,10 +103,8 @@ public class SocketCommandProcessor extends BaseCommandProcessor {
     public void processCommand() throws OpenAS2Exception
     {
 
-        SSLSocket socket = null;
-        try
+        try (SSLSocket socket =  (SSLSocket) sslserversocket.accept())
         {
-            socket = (SSLSocket) sslserversocket.accept();
             socket.setSoTimeout(2000);
             rdr = new BufferedReader(new InputStreamReader(socket.getInputStream()));
             wrtr = new BufferedWriter(new OutputStreamWriter(socket.getOutputStream()));
@@ -146,8 +143,7 @@ public class SocketCommandProcessor extends BaseCommandProcessor {
                     	wrtr.flush();
                     	rdr.close();
                     	wrtr.close();
-                    	IOUtils.closeQuietly(socket);
-                        terminate();
+                    	terminate();
                     } else
                     {
                         List<String> params = new ArrayList<String>();
@@ -202,9 +198,6 @@ public class SocketCommandProcessor extends BaseCommandProcessor {
         } catch (Exception e)
         {
             //nothing
-        } finally
-        {
-            IOUtils.closeQuietly(socket);
         }
 
     }
@@ -214,7 +207,7 @@ public class SocketCommandProcessor extends BaseCommandProcessor {
     {
     	if (logger.isTraceEnabled())
     			logger.trace("SocketCommandProcessor.destroy called...");
-        IOUtils.closeQuietly(sslserversocket);  // closes remote session
+        sslserversocket.close();  // closes remote session
         super.destroy();
 
     }

--- a/Server/src/main/java/org/openas2/partner/XMLPartnershipFactory.java
+++ b/Server/src/main/java/org/openas2/partner/XMLPartnershipFactory.java
@@ -18,7 +18,6 @@ import java.util.concurrent.TimeUnit;
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 
-import org.apache.commons.io.IOUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.openas2.OpenAS2Exception;
@@ -84,10 +83,8 @@ public class XMLPartnershipFactory extends BasePartnershipFactory implements Has
 
     void refresh() throws OpenAS2Exception
     {
-        FileInputStream inputStream = null;
-        try
+        try (FileInputStream inputStream = new FileInputStream(getFilename()))
         {
-            inputStream = new FileInputStream(getFilename());
             DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
 
             DocumentBuilder parser = factory.newDocumentBuilder();
@@ -123,9 +120,6 @@ public class XMLPartnershipFactory extends BasePartnershipFactory implements Has
         } catch (Exception e)
         {
             throw new WrappedException(e);
-        } finally
-        {
-            IOUtils.closeQuietly(inputStream);
         }
     }
 

--- a/Server/src/main/java/org/openas2/processor/storage/BaseStorageModule.java
+++ b/Server/src/main/java/org/openas2/processor/storage/BaseStorageModule.java
@@ -122,13 +122,12 @@ public abstract class BaseStorageModule extends BaseProcessorModule implements S
 
     protected void writeStream(InputStream in, File destination) throws IOException
     {
-        FileOutputStream out = new FileOutputStream(destination);
-        try
+        try (FileOutputStream out = new FileOutputStream(destination))
         {
             IOUtils.copy(in, out);
         } finally
         {
-            IOUtils.closeQuietly(in, out);
+            in.close();
         }
     }
 

--- a/Server/src/main/java/org/openas2/util/Properties.java
+++ b/Server/src/main/java/org/openas2/util/Properties.java
@@ -12,6 +12,7 @@ public class Properties
 	
 	public static String AS2_MESSAGE_ID_FORMAT = "as2_message_id_format";
 	public static String AS2_MDN_MESSAGE_ID_FORMAT = "as2_mdn_message_id_format";
+	public static String AS2_MESSAGE_ID_ENCLOSE_IN_BRACKETS = "as2_message_id_enclose_in_brackets";
 	
 	private static Map<String, String> _properties = new HashMap<String, String>();
 	

--- a/Server/src/test/java/org/openas2/app/HealthCheckTest.java
+++ b/Server/src/test/java/org/openas2/app/HealthCheckTest.java
@@ -7,7 +7,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 import org.junit.runner.RunWith;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 import org.openas2.TestResource;
 import org.openas2.processor.ActiveModule;
 import org.openas2.processor.receiver.NetModule;

--- a/Server/src/test/java/org/openas2/message/AS2MessageMDNTest.java
+++ b/Server/src/test/java/org/openas2/message/AS2MessageMDNTest.java
@@ -4,14 +4,19 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.exceptions.misusing.InvalidUseOfMatchersException;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.stubbing.Answer;
 import org.openas2.partner.AS2Partnership;
 import org.openas2.partner.Partnership;
 import org.openas2.util.Properties;
 
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
-import static org.mockito.Matchers.eq;
+import static org.mockito.ArgumentMatchers.matches;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 
 @RunWith(MockitoJUnitRunner.class)
@@ -21,21 +26,56 @@ public class AS2MessageMDNTest {
     private AS2Message message;
     @Mock
     private Partnership partnership;
+    
+    private static final String msgIdFmt = "OPENAS2-$date.ddMMyyyyHHmmssZ$-$rand.1234$@$msg.sender.as2_id$_$msg.receiver.as2_id$";
+    private static final String msgIdMatcher = "^<OPENAS2-[0-9]{14}[-+][0-9]{4}-[0-9]{4}@senderId_receiverId>";
+    private static final String msgIdMdnFmt = "MDN-$date.ddMMyyyyHHmmssZ$-$rand.1234$@$msg.sender.as2_id$_$msg.receiver.as2_id$";
+    private static final String msgIdMdnMatcher = "^<MDN-[0-9]{14}[-+][0-9]{4}-[0-9]{4}@senderId_receiverId>";
+    
+    private boolean returnMdnFmt = false;
 
     @Before
     public void setUp() throws Exception
     {
         when(message.getPartnership()).thenReturn(partnership);
-        when(partnership.getReceiverID(eq(AS2Partnership.PID_AS2))).thenReturn("receiverId");
-        when(partnership.getSenderID(eq(AS2Partnership.PID_AS2))).thenReturn("senderId");
-        when(message.getPartnership().getAttribute(eq(Properties.AS2_MESSAGE_ID_FORMAT)))
-        .thenReturn("OPENAS2-$date.ddMMyyyyHHmmssZ$-$rand.1234$@$msg.sender.as2_id$_$msg.receiver.as2_id$");
+        when(partnership.getReceiverID(matches(AS2Partnership.PID_AS2))).thenReturn("receiverId");
+        when(partnership.getSenderID(matches(AS2Partnership.PID_AS2))).thenReturn("senderId");
+        when(message.getPartnership().getAttributeOrProperty(anyString(), (String)any()))
+        .thenAnswer(
+        	    new Answer<Object>() {
+					@Override
+					public Object answer(InvocationOnMock invocation) throws Throwable {
+					    Object argument = invocation.getArguments()[0];
+					    if (argument.toString().equals(Properties.AS2_MDN_MESSAGE_ID_FORMAT)) {
+					    	if (returnMdnFmt) return msgIdMdnFmt;
+					    	else return null;
+					    } else if (argument.toString().equals(Properties.AS2_MESSAGE_ID_FORMAT)) {
+					        return msgIdFmt;
+					    } else if (argument.toString().equals(Properties.AS2_MESSAGE_ID_ENCLOSE_IN_BRACKETS)) {
+					        return "true";
+					    }
+					    throw new InvalidUseOfMatchersException(
+					        String.format("Argument %s does not match", argument)
+					    );
+					}
+				}
+        	);
     }
 
     @Test
     public void shouldGenerateMessageId() throws Exception
     {
+    	returnMdnFmt = false;
         String messageId = new AS2MessageMDN(message, false).generateMessageID();
-        assertThat("Check " + messageId, messageId.matches("^OPENAS2-[0-9]{14}[-+][0-9]{4}-[0-9]{4}@senderId_receiverId"), is(true));
+        assertThat("Check " + messageId, messageId.matches(msgIdMatcher), is(true));
+    }
+
+
+    @Test
+    public void shouldGenerateMdnMessageId() throws Exception
+    {
+    	returnMdnFmt = true;
+        String messageId = new AS2MessageMDN(message, false).generateMessageID();
+        assertThat("Check " + messageId, messageId.matches(msgIdMdnMatcher), is(true));
     }
 }

--- a/Server/src/test/java/org/openas2/params/ParameterParserTest.java
+++ b/Server/src/test/java/org/openas2/params/ParameterParserTest.java
@@ -4,7 +4,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 import org.openas2.message.AS2Message;
 import org.openas2.message.MessageMDN;
 import org.openas2.partner.AS2Partnership;
@@ -14,7 +14,7 @@ import org.openas2.util.StringUtil;
 
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
-import static org.mockito.Matchers.eq;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
 
 @RunWith(MockitoJUnitRunner.class)

--- a/Server/src/test/java/org/openas2/support/config/FileMonitorAdapterTest.java
+++ b/Server/src/test/java/org/openas2/support/config/FileMonitorAdapterTest.java
@@ -14,11 +14,11 @@ import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 import org.openas2.OpenAS2Exception;
 import org.openas2.support.FileMonitorAdapter;
 
-import static org.mockito.Matchers.eq;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;

--- a/Server/src/test/java/org/openas2/support/config/FileMonitorTest.java
+++ b/Server/src/test/java/org/openas2/support/config/FileMonitorTest.java
@@ -11,11 +11,11 @@ import org.junit.rules.TemporaryFolder;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.Mockito;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 import org.openas2.support.FileMonitor;
 import org.openas2.support.FileMonitorListener;
 
-import static org.mockito.Matchers.eq;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.verify;

--- a/Server/src/test/java/org/openas2/util/XMLUtilTest.java
+++ b/Server/src/test/java/org/openas2/util/XMLUtilTest.java
@@ -12,7 +12,7 @@ import javax.xml.transform.TransformerException;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 import org.openas2.lib.xml.PropertyReplacementFilter;
 import org.w3c.dom.Document;
 import org.xml.sax.helpers.XMLFilterImpl;


### PR DESCRIPTION
Provide ability for Message-ID to be encapsulated in angle brackets to conform with RFC4130 spec.
Handle possibility of no angle brackets in returned MDN or angle brackets added to Original-Message-ID when sent one was not encapsulated