### PR TITLE
Fix nullpointer exception when resending message with custom headers.

### DIFF
--- a/Server/src/main/java/org/openas2/message/BaseMessage.java
+++ b/Server/src/main/java/org/openas2/message/BaseMessage.java
@@ -364,6 +364,8 @@ public abstract class BaseMessage implements Message {
         if (MDN != null) {
             MDN.setMessage(this);
         }
+        
+        customOuterMimeHeaders = new HashMap<String, String>();
     }
 
     private void writeObject(java.io.ObjectOutputStream out)


### PR DESCRIPTION
Deserialization resets values to null instead of empty map. Set empty
map when deserializing. Fixes exception:

Exception in thread "DirectoryResenderModule"
java.lang.NullPointerException
        at org.openas2.message.BaseMessage.addCustomOuterMimeHeader(BaseMessage.java:89)
        at org.openas2.processor.sender.AS2SenderModule.addCustomHeaders(AS2SenderModule.java:461)
        at org.openas2.processor.sender.AS2SenderModule.handle(AS2SenderModule.java:92)
        at org.openas2.processor.DefaultProcessor.handle(DefaultProcessor.java:65)
        at org.openas2.processor.resender.DirectoryResenderModule.processFile(DirectoryResenderModule.java:186)
        at org.openas2.processor.resender.DirectoryResenderModule.resend(DirectoryResenderModule.java:106)
        at org.openas2.processor.resender.BaseResenderModule$PollTask.run(BaseResenderModule.java:34)
        at java.util.TimerThread.mainLoop(Timer.java:555)
        at java.util.TimerThread.run(Timer.java:505)