### PR TITLE
Option to disable chunking for specific partners.

### DIFF
--- a/Server/src/main/java/org/openas2/partner/Partnership.java
+++ b/Server/src/main/java/org/openas2/partner/Partnership.java
@@ -43,6 +43,7 @@ public class Partnership implements Serializable {
 	public static final String PA_CUSTOM_MIME_HEADER_NAMES_REGEX_ON_FILENAME = "custom_mime_header_names_regex_on_filename"; // Regex to split filename into values
 	public static final String PAIB_NAMES_FROM_FILENAME = "attribute_names_from_filename"; // List of attribute names to be set from parsed filename
 	public static final String PAIB_VALUES_REGEX_ON_FILENAME = "attribute_values_regex_on_filename"; // Regex to split filename into values
+	public static final String PA_HTTP_NO_CHUNKED_MAX_SIZE = "no_chunked_max_size"; // Disables chunked HTTP transfer when file size is set larger as 0 
 
 	/*
 	 * If set and an error occurs while processing a document, an error MDN will not be sent. This
@@ -227,4 +228,19 @@ public class Partnership implements Serializable {
     {
     	return "true".equalsIgnoreCase(getAttribute(Partnership.PA_REMOVE_PROTECTION_ATTRIB));
     }
+    
+    public boolean isNoChunkedTransfer()
+    {
+        return (getNoChunkedMaxSize() > 0L);
+    }
+    
+    public long getNoChunkedMaxSize()
+    {
+        long max = 0L;
+        try {
+            max = Long.valueOf(getAttribute(Partnership.PA_HTTP_NO_CHUNKED_MAX_SIZE));
+        } catch (Exception ignored) {}
+        return max;
+    }
+
 }

--- a/Server/src/main/java/org/openas2/processor/receiver/NetModule.java
+++ b/Server/src/main/java/org/openas2/processor/receiver/NetModule.java
@@ -113,7 +113,7 @@ public abstract class NetModule extends BaseReceiverModule {
 	    		logger.trace("Helthcheck about to try URL: " + urlString);
 	    	Map<String, String> options = new HashMap<String, String>();
 	    	options.put(HTTPUtil.HTTP_PROP_OVERRIDE_SSL_CHECKS, "true");
-			ResponseWrapper rw = HTTPUtil.execRequest(HTTPUtil.Method.GET, urlString, null, null, null, options);
+			ResponseWrapper rw = HTTPUtil.execRequest(HTTPUtil.Method.GET, urlString, null, null, null, options, 0L);
 	    	if (200 != rw.getStatusCode())
 	    	{
 	    		failures.add(this.getClass().getSimpleName()

--- a/Server/src/main/java/org/openas2/processor/sender/AS2SenderModule.java
+++ b/Server/src/main/java/org/openas2/processor/sender/AS2SenderModule.java
@@ -192,8 +192,9 @@ public class AS2SenderModule extends HttpSenderModule implements HasSchedule {
             logger.info("Connecting to: " + url + msg.getLogMsgID());
         }
 
+        long maxSize = msg.getPartnership().getNoChunkedMaxSize();
 		ResponseWrapper resp = HTTPUtil.execRequest(HTTPUtil.Method.POST, url, ih.getAllHeaders()
-				, null, securedData.getInputStream(), getHttpOptions());
+				, null, securedData.getInputStream(), getHttpOptions(), maxSize);
         if (logger.isInfoEnabled())
         {
             logger.info("Message sent and response received in " + resp.getTransferTimeMs() + "ms" + msg.getLogMsgID());

--- a/Server/src/main/java/org/openas2/processor/sender/MDNSenderModule.java
+++ b/Server/src/main/java/org/openas2/processor/sender/MDNSenderModule.java
@@ -113,7 +113,7 @@ public class MDNSenderModule extends HttpSenderModule {
 			if (logger.isDebugEnabled())
 				logger.debug("ASYNC MDN attempting connection to: " + url + mdn.getMessage().getLogMsgID());
 			ResponseWrapper resp = HTTPUtil.execRequest(HTTPUtil.Method.POST, url, mdn.getHeaders().getAllHeaders()
-					, null, mdn.getData().getInputStream(), getHttpOptions());
+					, null, mdn.getData().getInputStream(), getHttpOptions(), 0L);
 
 			int respCode = resp.getStatusCode();
 			// Check the HTTP Response code

--- a/Server/src/test/resources/OpenAS2ServerTest/OpenAS2B/config/partnerships.xml
+++ b/Server/src/test/resources/OpenAS2ServerTest/OpenAS2B/config/partnerships.xml
@@ -39,6 +39,7 @@
         <attribute name="subject" value="From OpenAS2B to OpenAS2A"/>
         <attribute name="as2_url" value="http://localhost:10080"/>
         <attribute name="as2_mdn_to" value="edi@openas2a.org"/>
+        <attribute name="no_chunked_max_size" value="10485760"/> <!-- Disables chunked transfer, set max. mime-size to 10 MB -->
          <!--   ...for async MDN-->
         <attribute name="as2_receipt_option" value="http://localhost:20081"/>
         <attribute name="as2_mdn_options"


### PR DESCRIPTION
Added partnership option no_chunked_max_size that, when set to a
positive number, will set a "Content-Length" header in the HTTP POST
message transfers and disables chunked transfer coding.

This option should not be needed in production, but can help with testing when faced with other AS2 servers that do not support chunked transfers. To make this a production feature, the implementation should use a temporary file to determine size (Content-Length) and stream from the temporary file to prevent abnormal memory usage.