### PR TITLE
Use a more generic solution for compatability with micalg values.

### DIFF
--- a/Server/src/main/java/org/openas2/lib/helper/BCCryptoHelper.java
+++ b/Server/src/main/java/org/openas2/lib/helper/BCCryptoHelper.java
@@ -139,8 +139,7 @@ public class BCCryptoHelper implements ICryptoHelper {
                 logger.trace("Compressed MIME msg AFTER COMPRESSION Content-Disposition:" + part.getDisposition());
             } catch (MessagingException e)
             {
-                // TODO Auto-generated catch block
-                e.printStackTrace();
+                logger.trace("Compression check: no data available.");
             }
         }
         if (baseType.equalsIgnoreCase("application/pkcs7-mime"))
@@ -344,7 +343,9 @@ public class BCCryptoHelper implements ICryptoHelper {
         PrivateKey privKey = castKey(key);
         String encryptAlg = cert.getPublicKey().getAlgorithm();
 
-        SMIMESignedGenerator sGen = new SMIMESignedGenerator();
+        // Fix copied from https://github.com/phax/as2-lib/commit/ed08dd00b6d721ec3e3e7255f642045c9cbee9c3
+        SMIMESignedGenerator sGen = new SMIMESignedGenerator(
+            adjustDigestToOldName ? SMIMESignedGenerator.RFC3851_MICALGS : SMIMESignedGenerator.RFC5751_MICALGS);
         sGen.setContentTransferEncoding(getEncoding(contentTxfrEncoding));
         SignerInfoGenerator sig;
         try
@@ -388,15 +389,8 @@ public class BCCryptoHelper implements ICryptoHelper {
 
         MimeBodyPart tmpBody = new MimeBodyPart();
         tmpBody.setContent(signedData);
-        String ct = signedData.getContentType();
-        // FIX for latest BC version setting the micalg value to sha-1 when passed sha1 as digest
-        if (adjustDigestToOldName && digest.equalsIgnoreCase("SHA1"))
-        {
-            ct = ct.replaceAll("-1", "1");
-        }
-        tmpBody.setHeader("Content-Type", ct);
-        //tmpBody.setHeader("Content-Transfer-Encoding", contentTxfrEncoding);
-
+        // Content-type header is required, unit tests fail badly on async MDNs if not set.
+        tmpBody.setHeader("Content-Type", signedData.getContentType());
         return tmpBody;
     }
 

--- a/Server/src/main/java/org/openas2/util/AS2Util.java
+++ b/Server/src/main/java/org/openas2/util/AS2Util.java
@@ -598,7 +598,7 @@ public class AS2Util {
 		if (!iFile.exists()) {
 			// try without the angle brackets in case they were added
 			String oMsgIdStripped = removeAngleBrackets(originalMsgId);
-			if (originalMsgId.equals(oMsgIdStripped)) {
+			if (oMsgIdStripped == null || originalMsgId.equals(oMsgIdStripped)) {
 				// No difference so...
 				throw new OpenAS2Exception("Pending info file missing: " + pendinginfofile);
 			}
@@ -762,8 +762,8 @@ public class AS2Util {
 		}
     }
     
-    public static String removeAngleBrackets(String srcString) {
-    	return srcString.replaceAll("^<([^>]+)>$", "$1");
+    private static String removeAngleBrackets(String srcString) {
+    	return (srcString == null ? null : srcString.replaceAll("^<([^>]+)>$", "$1"));
     }
 
 	public static void attributeEnhancer(Map<String, String> attribs) throws OpenAS2Exception {

--- a/Server/src/test/resources/OpenAS2ServerTest/OpenAS2A/config/partnerships.xml
+++ b/Server/src/test/resources/OpenAS2ServerTest/OpenAS2A/config/partnerships.xml
@@ -26,9 +26,7 @@
         <attribute name="sign" value="SHA1"/>
         <attribute name="resend_max_retries" value="3"/>
         <attribute name="prevent_canonicalization_for_mic" value="false"/>
-        <attribute name="no_set_transfer_encoding_for_signing" value="false"/>
-        <attribute name="no_set_transfer_encoding_for_encryption" value="false"/>
-        <attribute name="rename_digest_to_old_name" value="false"/>
+        <attribute name="rename_digest_to_old_name" value="true"/>
         <attribute name="remove_cms_algorithm_protection_attrib" value="false"/>
     </partnership>
 
@@ -47,6 +45,7 @@
         <attribute name="encrypt" value="3DES"/>
         <attribute name="sign" value="SHA256"/>
         <attribute name="prevent_canonicalization_for_mic" value="false"/>
+        <attribute name="rename_digest_to_old_name" value="false"/>
         <attribute name="remove_cms_algorithm_protection_attrib" value="false"/>
         <!--
         Example for adding static custom headers to Mime body part and additionally add to HTTP

--- a/Server/src/test/resources/OpenAS2ServerTest/OpenAS2B/config/partnerships.xml
+++ b/Server/src/test/resources/OpenAS2ServerTest/OpenAS2B/config/partnerships.xml
@@ -25,9 +25,7 @@
         <attribute name="sign" value="SHA1"/>
         <attribute name="resend_max_retries" value="3"/>
         <attribute name="prevent_canonicalization_for_mic" value="false"/>
-        <attribute name="no_set_transfer_encoding_for_signing" value="false"/>
-        <attribute name="no_set_transfer_encoding_for_encryption" value="false"/>
-        <attribute name="rename_digest_to_old_name" value="false"/>
+        <attribute name="rename_digest_to_old_name" value="true"/>
         <attribute name="remove_cms_algorithm_protection_attrib" value="false"/>
     </partnership>
 
@@ -47,6 +45,7 @@
         <attribute name="encrypt" value="3DES"/>
         <attribute name="sign" value="SHA256"/>
         <attribute name="prevent_canonicalization_for_mic" value="false"/>
+        <attribute name="rename_digest_to_old_name" value="false"/>
         <attribute name="remove_cms_algorithm_protection_attrib" value="false"/>
         <!--
         Example for adding static custom headers to Mime body part and additionally add to HTTP


### PR DESCRIPTION
The option "rename_digest_to_old_name" has generic support in
BouncyCastle, so use that. Solution similar to:
https://github.com/phax/as2-lib/commit/ed08dd00b6d721ec3e3e7255f642045c9cbee9c3

Fix a couple of unhelpful NullPointerExceptions and remove 2 partnership
options that no longer exist.