### PR TITLE
Use a basic connection manager for the HTTP Client.

### DIFF
--- a/Server/src/main/java/org/openas2/util/HTTPUtil.java
+++ b/Server/src/main/java/org/openas2/util/HTTPUtil.java
@@ -1,17 +1,15 @@
 package org.openas2.util;
 
-import java.io.*;
-import java.net.Authenticator;
-import java.net.HttpURLConnection;
-import java.net.InetAddress;
-import java.net.InetSocketAddress;
-import java.net.NetworkInterface;
-import java.net.PasswordAuthentication;
-import java.net.Proxy;
-import java.net.SocketException;
-import java.net.URISyntaxException;
-import java.net.URL;
-import java.net.URLEncoder;
+import java.io.BufferedInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.DataInputStream;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.io.UnsupportedEncodingException;
+import java.net.*;
 import java.security.KeyStore;
 import java.security.cert.CertificateException;
 import java.security.cert.X509Certificate;
@@ -44,7 +42,11 @@ import org.apache.http.auth.UsernamePasswordCredentials;
 import org.apache.http.client.CredentialsProvider;
 import org.apache.http.client.config.RequestConfig;
 import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.client.methods.HttpUriRequest;
 import org.apache.http.client.methods.RequestBuilder;
+import org.apache.http.config.RegistryBuilder;
+import org.apache.http.conn.socket.ConnectionSocketFactory;
+import org.apache.http.conn.socket.PlainConnectionSocketFactory;
 import org.apache.http.conn.ssl.SSLConnectionSocketFactory;
 import org.apache.http.conn.ssl.TrustSelfSignedStrategy;
 import org.apache.http.entity.ByteArrayEntity;
@@ -52,17 +54,13 @@ import org.apache.http.entity.InputStreamEntity;
 import org.apache.http.impl.client.BasicCredentialsProvider;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClientBuilder;
-import org.apache.http.impl.client.HttpClients;
+import org.apache.http.impl.conn.BasicHttpClientConnectionManager;
 import org.apache.http.ssl.SSLContexts;
 import org.openas2.OpenAS2Exception;
 import org.openas2.WrappedException;
 import org.openas2.message.Message;
 
 
-/**
- * @author Christopher
- *
- */
 /**
  * @author Christopher
  *
@@ -325,101 +323,105 @@ public class HTTPUtil {
 	 * @throws Exception
 	 */
 	public static ResponseWrapper execRequest(String method, String url
-			, Enumeration<Header> headers, NameValuePair[] params
-			, InputStream inputStream, Map<String, String> options, long noChunkMaxSize) throws Exception {
+	    , Enumeration<Header> headers, NameValuePair[] params
+	    , InputStream inputStream, Map<String, String> options, long noChunkMaxSize) throws Exception {
 
-		String connectTimeOutStr = options.get(PARAM_CONNECT_TIMEOUT);
-		String readTimeOutStr = options.get(PARAM_READ_TIMEOUT);
-		String socketTimeOutStr = options.get(PARAM_SOCKET_TIMEOUT);
-		CloseableHttpClient httpClient = null;
-		CloseableHttpResponse response = null;
-		HttpClientBuilder httpBuilder = HttpClientBuilder.create();
-		RequestConfig.Builder cfgBuilder = RequestConfig.custom();
-		if (connectTimeOutStr != null) cfgBuilder.setConnectTimeout(Integer.parseInt(connectTimeOutStr));
-		if (readTimeOutStr != null) cfgBuilder.setConnectionRequestTimeout(Integer.parseInt(readTimeOutStr));
-		if (socketTimeOutStr != null) cfgBuilder.setSocketTimeout(Integer.parseInt(socketTimeOutStr));
-		RequestConfig config = cfgBuilder.build();
+	    HttpClientBuilder httpBuilder = HttpClientBuilder.create();
+	    URL urlObj = new URL(url);
+	    /*
+	     * httpClient is used for this request only,
+	     * set a connection manager that manages just one connection. 
+	     */
+	    if (urlObj.getProtocol().equalsIgnoreCase("https")) {
+	        /*
+	         * Note: registration of a custom SSLSocketFactory via httpBuilder.setSSLSocketFactory is ignored when a connection manager is set.
+	         * The custom SSLSocketFactory needs to be registered together with the connection manager.
+	         */
+	        SSLConnectionSocketFactory sslCsf = buildSslFactory(urlObj, options);
+	        httpBuilder.setConnectionManager(new BasicHttpClientConnectionManager(
+	            RegistryBuilder.<ConnectionSocketFactory>create()
+	            .register("http", PlainConnectionSocketFactory.getSocketFactory())
+	            .register("https", sslCsf)
+	            .build()
+	        ));
+	    } else {
+	        httpBuilder.setConnectionManager(new BasicHttpClientConnectionManager());
+	    }
 
-		URL urlObj = new URL(url);
+	    RequestBuilder rb = getRequestBuilder(method, urlObj, params, headers);
+	    RequestConfig.Builder rcBuilder = buildRequestConfig(options);
+	    setProxyConfig(httpBuilder, rcBuilder, urlObj.getProtocol());
+	    rb.setConfig(rcBuilder.build());
 
-		if (urlObj.getProtocol().equalsIgnoreCase("https")) {
-			boolean overrideSslChecks = "true".equalsIgnoreCase(options.get(HTTPUtil.HTTP_PROP_OVERRIDE_SSL_CHECKS));
-			SSLContext sslcontext;
-			String selfSignedCN = System.getProperty("org.openas2.cert.TrustSelfSignedCN");
-			if ((selfSignedCN != null && selfSignedCN.contains(urlObj.getHost())) || overrideSslChecks) {
-				File file = getTrustedCertsKeystore();
-				InputStream in = new FileInputStream(file);
-				try {
-					KeyStore ks = KeyStore.getInstance(KeyStore.getDefaultType());
-					ks.load(in, "changeit".toCharArray());
-					in.close();
-
-					// Trust own CA and all self-signed certs
-					sslcontext = SSLContexts.custom().loadTrustMaterial(ks, new TrustSelfSignedStrategy()).build();
-					// Allow TLSv1 protocol only by default
-				} catch (Exception e) {
-					throw new OpenAS2Exception("Self-signed certificate URL connection failed connecting to : " + url,
-							e);
-				}
-			} else {
-				sslcontext = SSLContexts.createSystemDefault();
-			}
-			// String [] protocols = Properties.getProperty(HTTP_PROP_SSL_PROTOCOLS,
-			// "TLSv1").split("\\s*,\\s*");
-			HostnameVerifier hnv = SSLConnectionSocketFactory.getDefaultHostnameVerifier();
-			if (overrideSslChecks) {
-				hnv = new HostnameVerifier() {
-					@Override
-					public boolean verify(String hostname, SSLSession session) {
-						return true;
-					}
-				};
-			}
-
-			SSLConnectionSocketFactory sslsf = new SSLConnectionSocketFactory(sslcontext, null, null,
-					hnv);
-			httpBuilder = HttpClients.custom().setSSLSocketFactory(sslsf);
-		}
-
-		try {
-			RequestBuilder rb = getRequestBuilder(method, urlObj, params, headers);
-			rb.setConfig(config);
-			setProxyConfig(httpBuilder, rb, urlObj.getProtocol());
-
- 			if (inputStream != null) {
- 			    if (noChunkMaxSize > 0L) {
-                    ByteArrayOutputStream bout = new ByteArrayOutputStream();
-                    long copied = IOUtils.copyLarge(inputStream, bout, 0L, noChunkMaxSize + 1, new byte[8192]);
-                    if (copied > noChunkMaxSize) {
-                        throw new IOException("Mime inputstream too big to put in memory (more than " + noChunkMaxSize + " bytes).");
-                    }
-                    ByteArrayEntity bae = new ByteArrayEntity(bout.toByteArray(), null);
-                    rb.setEntity(bae);
- 			    } else {
-                    InputStreamEntity ise = new InputStreamEntity(inputStream);
-                    rb.setEntity(ise);
- 			    }
-			}
-			httpClient = httpBuilder.build();
-            ProfilerStub transferStub = Profiler.startProfile();
-			response = httpClient.execute(rb.build());
-            Profiler.endProfile(transferStub);
-            ResponseWrapper resp = new ResponseWrapper(response);
-            resp.setTransferTimeMs( transferStub.getMilliseconds());
-            for (org.apache.http.Header header : response.getAllHeaders()) {
-				resp.addHeaderLine(header.toString());
-			}
-			return resp;
-		} catch (Exception e) {
-			throw e;
-		} finally {
-			if (httpClient != null) httpClient.close();
-			if (response!= null) response.close();
-		}
+	    if (inputStream != null) {
+	        if (noChunkMaxSize > 0L) {
+	            ByteArrayOutputStream bout = new ByteArrayOutputStream();
+	            long copied = IOUtils.copyLarge(inputStream, bout, 0L, noChunkMaxSize + 1, new byte[8192]);
+	            if (copied > noChunkMaxSize) {
+	                throw new IOException("Mime inputstream too big to put in memory (more than " + noChunkMaxSize + " bytes).");
+	            }
+	            ByteArrayEntity bae = new ByteArrayEntity(bout.toByteArray(), null);
+	            rb.setEntity(bae);
+	        } else {
+	            InputStreamEntity ise = new InputStreamEntity(inputStream);
+	            rb.setEntity(ise);
+	        }
+	    }
+	    final HttpUriRequest request = rb.build();
+	    try (CloseableHttpClient httpClient = httpBuilder.build()) {
+	        ProfilerStub transferStub = Profiler.startProfile();
+	        try (CloseableHttpResponse response = httpClient.execute(request)) {
+	            ResponseWrapper resp = new ResponseWrapper(response);
+	            Profiler.endProfile(transferStub);
+	            resp.setTransferTimeMs( transferStub.getMilliseconds());
+	            for (org.apache.http.Header header : response.getAllHeaders()) {
+	                resp.addHeaderLine(header.toString());
+	            }
+	            return resp;
+	        }
+	    }
 	}
-
-    protected static RequestBuilder getRequestBuilder(String method, URL urlObj
+	
+	private static SSLConnectionSocketFactory buildSslFactory(URL urlObj, Map<String, String> options) throws Exception {
+	    
+        boolean overrideSslChecks = "true".equalsIgnoreCase(options.get(HTTPUtil.HTTP_PROP_OVERRIDE_SSL_CHECKS));
+        SSLContext sslcontext;
+        String selfSignedCN = System.getProperty("org.openas2.cert.TrustSelfSignedCN");
+        if ((selfSignedCN != null && selfSignedCN.contains(urlObj.getHost())) || overrideSslChecks) {
+            File file = getTrustedCertsKeystore();
+            KeyStore ks = null;
+            try (InputStream in = new FileInputStream(file)) {
+                ks = KeyStore.getInstance(KeyStore.getDefaultType());
+                ks.load(in, "changeit".toCharArray());
+            }
+            try {
+                // Trust own CA and all self-signed certs
+                sslcontext = SSLContexts.custom().loadTrustMaterial(ks, new TrustSelfSignedStrategy()).build();
+                // Allow TLSv1 protocol only by default
+            } catch (Exception e) {
+                throw new OpenAS2Exception("Self-signed certificate URL connection failed connecting to : " + urlObj.toString(), e);
+            }
+        } else {
+            sslcontext = SSLContexts.createSystemDefault();
+        }
+        // String [] protocols = Properties.getProperty(HTTP_PROP_SSL_PROTOCOLS,
+        // "TLSv1").split("\\s*,\\s*");
+        HostnameVerifier hnv = SSLConnectionSocketFactory.getDefaultHostnameVerifier();
+        if (overrideSslChecks) {
+            hnv = new HostnameVerifier() {
+                @Override
+                public boolean verify(String hostname, SSLSession session) {
+                    return true;
+                }
+            };
+        }
+        SSLConnectionSocketFactory sslsf = new SSLConnectionSocketFactory(sslcontext, null, null, hnv);
+        return sslsf;
+	}
+	
+    private static RequestBuilder getRequestBuilder(String method, URL urlObj
     		, NameValuePair[] params, Enumeration<Header> headers) throws URISyntaxException {
+        
     	RequestBuilder req = null;
         if (method == null || method.equalsIgnoreCase(Method.GET)) {
             //default get
@@ -452,6 +454,18 @@ public class HTTPUtil {
 			}
 		}
 		return req;
+    }
+
+    private static RequestConfig.Builder buildRequestConfig(Map<String, String> options) {
+
+        String connectTimeOutStr = options.get(PARAM_CONNECT_TIMEOUT);
+        String readTimeOutStr = options.get(PARAM_READ_TIMEOUT);
+        String socketTimeOutStr = options.get(PARAM_SOCKET_TIMEOUT);
+        RequestConfig.Builder rcBuilder = RequestConfig.custom();
+        if (connectTimeOutStr != null) rcBuilder.setConnectTimeout(Integer.parseInt(connectTimeOutStr));
+        if (readTimeOutStr != null) rcBuilder.setConnectionRequestTimeout(Integer.parseInt(readTimeOutStr));
+        if (socketTimeOutStr != null) rcBuilder.setSocketTimeout(Integer.parseInt(socketTimeOutStr));
+        return rcBuilder;
     }
 
 	/*
@@ -662,7 +676,7 @@ public class HTTPUtil {
 		}
 	}
 
-	private static void setProxyConfig(HttpClientBuilder builder, RequestBuilder request,
+	private static void setProxyConfig(HttpClientBuilder builder, RequestConfig.Builder rcBuilder,
 			String protocol) throws OpenAS2Exception {
 		String proxyHost = Properties.getProperty(protocol + ".proxyHost", null);
 		if (proxyHost == null)
@@ -677,8 +691,7 @@ public class HTTPUtil {
 		int port = Integer.parseInt(proxyPort);
 		HttpHost proxy = new HttpHost(proxyHost, port);
 
-		RequestConfig config = RequestConfig.custom().setProxy(proxy).build();
-		request.setConfig(config);
+		rcBuilder.setProxy(proxy);
 
 		String proxyUser1 = Properties.getProperty("http.proxyUser", null);
 		final String proxyUser = proxyUser1 == null ? System.getProperty("http.proxyUser") : proxyUser1;
@@ -690,7 +703,6 @@ public class HTTPUtil {
 		credsProvider.setCredentials(new AuthScope(proxyHost, port),
 				new UsernamePasswordCredentials(proxyUser, proxyPassword));
 		builder.setDefaultCredentialsProvider(credsProvider);
-
 	}
 
 	/**


### PR DESCRIPTION
The default pooling connection manager adds setup costs for creating a
HTTP Client that is only used for one request. The basic connection
manager only handles one connection and reduces setup costs.
Also improve request configuration building - proxy-configuration no
longer overwrites "options" (connection timeouts) configuration.