### PR TITLE
Systemd service uses OPENAS2_PID, startup script must use that too.

### DIFF
--- a/Server/src/bin/start-openas2.bat
+++ b/Server/src/bin/start-openas2.bat
@@ -8,6 +8,8 @@ set EXTRA_PARMS=-Xms32m -Xmx384m  -Dorg.apache.commons.logging.Log=org.openas2.l
 rem For versions of Java that prevent restricted HTTP headers (see documentation for discussion on this)
 rem set EXTRA_PARMS=%EXTRA_PARMS% -Dsun.net.http.allowRestrictedHeaders=true
 
+rem When using old (unsecure) certificates (please replace them!) that fail to load from the certificate store.
+rem set EXTRA_PARMS=%EXTRA_PARMS% -Dorg.bouncycastle.asn1.allow_unsafe_integer=true
 
 rem set EXTRA_PARMS=%EXTRA_PARMS% -Dhttps.protocols=TLSv1.2
 

--- a/Server/src/bin/start-openas2.sh
+++ b/Server/src/bin/start-openas2.sh
@@ -7,12 +7,18 @@ binDir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 keyStorePwd=$1
 PWD_OVERRIDE=""
 
-if [ -z $OPENAS2_PID ]; then
+# Backwards compatibility: use value from pid_file if pid_file has a value and openas2_pid has no value.
+#
+if [ -n "$PID_FILE" ] && [ -z "$OPENAS2_PID" ]; then
+  export OPENAS2_PID=$PID_FILE
+fi
+
+if [ -z "$OPENAS2_PID" ]; then
   export OPENAS2_PID=$binDir/OpenAS2.pid
 fi
 
 # Set some of the base system properties for the Java environment and logging
-# remove -Dorg.apache.commons.logging.Log=org.openas2.logging.Log if using another logging package    
+# remove -Dorg.apache.commons.logging.Log=org.openas2.logging.Log if using another logging package
 #
 EXTRA_PARMS="-Xms32m -Xmx384m -Dorg.apache.commons.logging.Log=org.openas2.logging.Log"
 

--- a/Server/src/bin/start-openas2.sh
+++ b/Server/src/bin/start-openas2.sh
@@ -7,8 +7,8 @@ binDir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 keyStorePwd=$1
 PWD_OVERRIDE=""
 
-if [ -z $PID_FILE ]; then
-  export PID_FILE=$binDir/OpenAS2.pid
+if [ -z $OPENAS2_PID ]; then
+  export OPENAS2_PID=$binDir/OpenAS2.pid
 fi
 
 # Set some of the base system properties for the Java environment and logging
@@ -21,6 +21,9 @@ EXTRA_PARMS="$EXTRA_PARMS -Dopenas2.config.file=${binDir}/../config/config.xml"
 
 # For versions of Java that prevent restricted HTTP headers (see documentation for discussion on this)
 #EXTRA_PARMS="$EXTRA_PARMS -Dsun.net.http.allowRestrictedHeaders=true"
+
+# When using old (unsecure) certificates (please replace them!) that fail to load from the certificate store.
+#EXTRA_PARMS="$EXTRA_PARMS -Dorg.bouncycastle.asn1.allow_unsafe_integer=true"
 
 #EXTRA_PARMS="$EXTRA_PARMS -Dhttps.protocols=TLSv1.2"
 
@@ -62,8 +65,8 @@ if [ "true" = "$OPENAS2_AS_DAEMON" ]; then
   RETVAL="$?"
   PID=$!
   if [ "$RETVAL" = 0 ]; then
-    echo "Writing PID $PID to file $PID_FILE"
-    echo $PID > $PID_FILE
+    echo "Writing PID $PID to file $OPENAS2_PID"
+    echo $PID > $OPENAS2_PID
   fi
 else
   ${CMD}


### PR DESCRIPTION
Starting OpenAS2 with openas2.service fails when the PID-file location
is changed because the start-script does not use the OPENAS2_PID
variable set by the service. The start-script used PID_FILE.

Also tweak the start-script example with EXTRA_PARMS for using old
certificates ("org.bouncycastle.asn1.allow_unsafe_integer").