### PR TITLE
Optimize move-file method to use atomic move.

### DIFF
--- a/Server/src/main/java/org/openas2/processor/storage/BaseStorageModule.java
+++ b/Server/src/main/java/org/openas2/processor/storage/BaseStorageModule.java
@@ -113,7 +113,7 @@ public abstract class BaseStorageModule extends BaseProcessorModule implements S
             writeStream(in, tempFile);
 
             // copy the temp file over to the destination
-            IOUtil.moveFile(tempFile, msgFile, true, false);
+            IOUtil.moveFile(tempFile, msgFile, true);
         } else
         {
             writeStream(in, msgFile);

--- a/Server/src/main/java/org/openas2/util/AS2Util.java
+++ b/Server/src/main/java/org/openas2/util/AS2Util.java
@@ -422,7 +422,7 @@ public class AS2Util {
 				logger.trace("Attempting to rename pending info file : " + oldPendInfFile.getName() + " :::: New name: "
 						+ newPendInfFile.getName() + msg.getLogMsgID());
 			try {
-				newPendInfFile = IOUtil.moveFile(oldPendInfFile, newPendInfFile, false, true);
+				newPendInfFile = IOUtil.moveFile(oldPendInfFile, newPendInfFile, false);
 				// Update the name of the file in the message object
 				msg.setAttribute(FileAttribute.MA_PENDINGINFO, newPendingInfoFileName);
 				if (logger.isInfoEnabled())
@@ -736,7 +736,7 @@ public class AS2Util {
 					try
 					{
 						tgtFile = new File(tgtDir + "/" + fPendingFile.getName());
-						tgtFile = IOUtil.moveFile(fPendingFile, tgtFile, false, true);
+						tgtFile = IOUtil.moveFile(fPendingFile, tgtFile, false);
 						isMoved = true;
 
 						if (logger.isInfoEnabled())


### PR DESCRIPTION
The move-file method did a lot of file operations that could mostly be
skipped on the "happy path". In some cases an atomic move is required
(e.g. moving a file to an inbox), debug logging will now show the
move-operation. Also made the "create directories" call synchronized to
prevent any race-conditions and log which directories are created.
Removed some pre Java 7 code in the file-delete method that is no longer
needed.