### PR TITLE
Consider non base64 encodings being rather binary

### DIFF
--- a/Server/src/main/java/org/openas2/lib/helper/BCCryptoHelper.java
+++ b/Server/src/main/java/org/openas2/lib/helper/BCCryptoHelper.java
@@ -528,7 +528,7 @@ public class BCCryptoHelper implements ICryptoHelper {
 
     protected String getEncoding(String contentTxfrEncoding)
     {
-        // Bouncy castle only deals with binary or base64 so pass base64 for 7bit, 8bit etc
+        // Bouncy castle only deals with binary or base64 so pass binary for 7bit, 8bit etc
         return "base64".equalsIgnoreCase(contentTxfrEncoding) ? "base64" : "binary";
     }
 

--- a/Server/src/main/java/org/openas2/lib/helper/BCCryptoHelper.java
+++ b/Server/src/main/java/org/openas2/lib/helper/BCCryptoHelper.java
@@ -529,7 +529,7 @@ public class BCCryptoHelper implements ICryptoHelper {
     protected String getEncoding(String contentTxfrEncoding)
     {
         // Bouncy castle only deals with binary or base64 so pass base64 for 7bit, 8bit etc
-        return "binary".equalsIgnoreCase(contentTxfrEncoding) ? "binary" : "base64";
+        return "base64".equalsIgnoreCase(contentTxfrEncoding) ? "base64" : "binary";
     }
 
     protected X509Certificate castCertificate(Certificate cert) throws GeneralSecurityException


### PR DESCRIPTION
The previous version presumes that 7-bit, 8-bit or even quoted-printable encodings can be handled using base64 decoders which is obviously not true and it's better to handle these as binary.