### PR TITLE
Decreased noise in logs

### DIFF
--- a/Server/src/main/java/org/openas2/processor/receiver/AS2ReceiverHandler.java
+++ b/Server/src/main/java/org/openas2/processor/receiver/AS2ReceiverHandler.java
@@ -73,8 +73,8 @@ public class AS2ReceiverHandler implements NetModuleHandler {
     }
 
     public void handle(NetModule owner, Socket s) {
-        if (LOG.isInfoEnabled()) {
-            LOG.info("incoming connection" + getClientInfo(s));
+        if (LOG.isDebugEnabled()) {
+            LOG.debug("incoming connection" + getClientInfo(s));
         }
 
         AS2Message msg = createMessage(s);
@@ -110,8 +110,8 @@ public class AS2ReceiverHandler implements NetModuleHandler {
             String mic = null;
             if (data == null) {
                 if ("true".equalsIgnoreCase(msg.getAttribute("isHealthCheck"))) {
-                    if (LOG.isInfoEnabled()) {
-                        LOG.info("Healthcheck ping detected" + " [" + getClientInfo(s) + "]" + msg.getLogMsgID());
+                    if (LOG.isDebugEnabled()) {
+                        LOG.debug("Healthcheck ping detected" + " [" + getClientInfo(s) + "]" + msg.getLogMsgID());
                     }
                     return;
                 } else {


### PR DESCRIPTION
If a monitoring system invokes the health check each 30s, OpenAS will
generate useless 5760 log entries. Those log entries are noise can
can overwhelm the log analytics systems. The log level for those
two entries has been decreased to DEBUG. Logging for the real data
transfers as well as for the errors still present.