### PR TITLE
Update Dockerfile and start-container.sh

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,15 +17,15 @@ RUN cd /usr/src/openas2/Runtime/bin && \
 
 
 FROM openjdk:11-jre-slim 
-ENV OPENAS2_BASE=/opt/openas2/
-ENV OPENAS2_HOME=/opt/openas2/
+ENV OPENAS2_BASE=/opt/openas2
+ENV OPENAS2_HOME=/opt/openas2
 ENV OPENAS2_TMPDIR=/opt/openas2/temp
-COPY --from=builder /usr/src/openas2/Runtime/bin $OPENAS2_BASE
-COPY --from=builder /usr/src/openas2/Runtime/lib $OPENAS2_BASE
-COPY --from=builder /usr/src/openas2/Runtime/resources $OPENAS2_BASE
-COPY --from=builder /usr/src/openas2/Runtime/config_template $OPENAS2_HOME
+COPY --from=builder /usr/src/openas2/Runtime/bin ${OPENAS2_BASE}/bin
+COPY --from=builder /usr/src/openas2/Runtime/lib ${OPENAS2_BASE}/lib
+COPY --from=builder /usr/src/openas2/Runtime/resources ${OPENAS2_BASE}/resources
+COPY --from=builder /usr/src/openas2/Runtime/config_template ${OPENAS2_HOME}/config_template
 WORKDIR $OPENAS2_HOME
-ENTRYPOINT $OPENAS2_BASE/bin/start-container.sh
+ENTRYPOINT ${OPENAS2_BASE}/bin/start-container.sh
 
 
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,6 +24,7 @@ COPY --from=builder /usr/src/openas2/Runtime/bin ${OPENAS2_BASE}/bin
 COPY --from=builder /usr/src/openas2/Runtime/lib ${OPENAS2_BASE}/lib
 COPY --from=builder /usr/src/openas2/Runtime/resources ${OPENAS2_BASE}/resources
 COPY --from=builder /usr/src/openas2/Runtime/config_template ${OPENAS2_HOME}/config_template
+RUN mkdir ${OPENAS2_BASE}/config
 WORKDIR $OPENAS2_HOME
 ENTRYPOINT ${OPENAS2_BASE}/bin/start-container.sh
 

--- a/start-container.sh
+++ b/start-container.sh
@@ -3,7 +3,6 @@
 if [ ! -e /opt/openas2/config/config.xml ]
     then
         echo "The config folder is empty, it will be populated by the template..."
-        cd config_template
         cp -a config_template/* config/
         echo "Done!"
 fi


### PR DESCRIPTION
Dockerfile:
1. Removed the trailing / in the environment variables. Doing this made the rest of the file look more readable. Dockerfile also accepts variable references in the form ${variable}. This helps when joining variables and strings.
2. Added the destination directories to the COPY commands. All the files were being dumped into the $OPENAS2_HOME directory.
3. Created config directory

start-container.sh:
1. Removed 'cd' command. There is no config_template directory inside the config_template directory.

I would also like to point out that if $OPENAS2_BASE and $OPENAS2_HOME are different, start-container.sh will fail to copy the files and OpenAS2 will complain about no config.xml.

#226 