### PR TITLE
Add no-console rule to WebUI

### DIFF
--- a/WebUI/package.json
+++ b/WebUI/package.json
@@ -25,6 +25,9 @@
   },
   "eslintConfig": {
     "root": true,
+	"rules":{
+		"no-console":"off"
+	},
     "env": {
       "node": true
     },


### PR DESCRIPTION
no-console rule is needed to avoid getting errors on build when console.log is found within the src.