### PR TITLE
Remove double quotes from as2id on sync mdns

### DIFF
--- a/Server/src/main/java/org/openas2/util/AS2Util.java
+++ b/Server/src/main/java/org/openas2/util/AS2Util.java
@@ -443,8 +443,8 @@ public class AS2Util {
             logger.trace("HTTP headers in received MDN: " + AS2Util.printHeaders(mdn.getHeaders().getAllHeaders()));
         }
         // get the MDN partnership info
-        mdn.getPartnership().setSenderID(Partnership.PID_AS2, mdn.getHeader("AS2-From"));
-        mdn.getPartnership().setReceiverID(Partnership.PID_AS2, mdn.getHeader("AS2-To"));
+        mdn.getPartnership().setSenderID(Partnership.PID_AS2, StringUtil.removeDoubleQuotes(mdn.getHeader("AS2-From")));
+        mdn.getPartnership().setReceiverID(Partnership.PID_AS2, StringUtil.removeDoubleQuotes(mdn.getHeader("AS2-To")));
         session.getPartnershipFactory().updatePartnership(mdn, false);
 
         MimeBodyPart part;


### PR DESCRIPTION
Not sure if opening a PR like this is helpful, but this is the change I needed to make to resolve an issue I was having with synchronous MDN processing.  It appears to be similar to code changes I looked at:

here: https://github.com/OpenAS2/OpenAs2App/pull/93 
and here: https://github.com/OpenAS2/OpenAs2App/pull/92

I was getting a PartnershipNotFound exception when processing an MDN response for a partner who is using a space in their AS2 identifier.  

This change seems to fix the issue.  With some guidance I'm willing to write some tests/clean this up if we think this is something worth pulling into the main project. 