### PR TITLE
Fix: JacksonFeature not registered

### DIFF
--- a/Server/src/main/java/org/openas2/cmd/processor/RestCommandProcessor.java
+++ b/Server/src/main/java/org/openas2/cmd/processor/RestCommandProcessor.java
@@ -96,9 +96,11 @@ public class RestCommandProcessor extends BaseCommandProcessor {
             // Now needed to define packages in Jersey 3.0
             final ResourceConfig rc = new ResourceConfig();
             rc.packages("org.openas2.cmd.processor.restapi");
+            rc.packages("org.glassfish.jersey.jackson");
             rc.register(SecurityEntityFilteringFeature.class);
             rc.register(EntityFilteringFeature.class);
             rc.register(RolesAllowedDynamicFeature.class);
+            rc.register(JacksonFeature.class);
             //rc.registerClasses(LoggerRequestFilter.class);
             URI baseUri = URI.create(parameters.getOrDefault("baseuri", BASE_URI));
 


### PR DESCRIPTION
It looks like that this PR https://github.com/OpenAS2/OpenAs2App/pull/270 broke the JSON encoding. This broke the WebUI. I readded `JacksonFeature.class`, assuming it was removed unintentionally. 

Before:

![Screenshot from 2022-05-23 10-44-21](https://user-images.githubusercontent.com/1880828/169780576-ee6b93f5-9403-4973-a5fe-25a449745fef.png)

With the fix in this PR:

![Screenshot from 2022-05-23 10-42-38](https://user-images.githubusercontent.com/1880828/169780645-dbfdbee2-d8cb-46b9-8ccf-2cca4f855d18.png)

 