### PR TITLE
Fix: Fix polledDirectories not cleared on destroy

### DIFF
--- a/Server/src/main/java/org/openas2/BaseSession.java
+++ b/Server/src/main/java/org/openas2/BaseSession.java
@@ -14,6 +14,7 @@ import org.w3c.dom.Node;
 
 import javax.activation.CommandMap;
 import javax.activation.MailcapCommandMap;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -133,17 +134,20 @@ public abstract class BaseSession implements Session {
     }
 
     public void destroyPartnershipPollers() {
+        ArrayList<String> removeKeys = new ArrayList<String>();
         for (Map.Entry<String, Map<String, Object>> entry : polledDirectories.entrySet()) {
             Map<String, Object> meta = entry.getValue();
             ProcessorModule poller = (ProcessorModule) meta.get("pollerInstance");
             try {
                 poller.destroy();
+                removeKeys.add(entry.getKey());
             } catch (Exception e) {
                 // something went wrong stoppint it - report and keep going
                 LOGGER.error("Failed to stop a partnership poller for directory " + entry.getKey() + ": " + meta, e);
             }
-            
         }
+        // remove keys
+        removeKeys.forEach(s -> polledDirectories.remove(s));
     }
 
     public void loadPartnershipPoller(Node moduleNode, String partnershipName, String configSource) throws OpenAS2Exception {

--- a/Server/src/main/java/org/openas2/cmd/processor/RestCommandProcessor.java
+++ b/Server/src/main/java/org/openas2/cmd/processor/RestCommandProcessor.java
@@ -96,9 +96,11 @@ public class RestCommandProcessor extends BaseCommandProcessor {
             // Now needed to define packages in Jersey 3.0
             final ResourceConfig rc = new ResourceConfig();
             rc.packages("org.openas2.cmd.processor.restapi");
+            rc.packages("org.glassfish.jersey.jackson");
             rc.register(SecurityEntityFilteringFeature.class);
             rc.register(EntityFilteringFeature.class);
             rc.register(RolesAllowedDynamicFeature.class);
+            rc.register(JacksonFeature.class);
             //rc.registerClasses(LoggerRequestFilter.class);
             URI baseUri = URI.create(parameters.getOrDefault("baseuri", BASE_URI));
 


### PR DESCRIPTION
I noticed this when modifying `partnerships.xml`, when the config is reloaded from disk, the following exception occurs: 

```
buymore_1       | 2022-05-30 11:32:17.990 ERROR OpenAS2Exception: Error occurred:: Partnership cannot be loaded because there is a configuration error: Buymore2Largemart
buymore_1       |     Sources: {}
buymore_1       | org.openas2.WrappedException: org.openas2.OpenAS2Exception: Partnership cannot be loaded because there is a configuration error: Buymore2Largemart
buymore_1       | 	at org.openas2.partner.XMLPartnershipFactory.refreshConfig(XMLPartnershipFactory.java:140)
buymore_1       | 	at org.openas2.partner.XMLPartnershipFactory.refresh(XMLPartnershipFactory.java:96)
buymore_1       | 	at org.openas2.partner.XMLPartnershipFactory$1.onConfigFileChanged(XMLPartnershipFactory.java:294)
buymore_1       | 	at org.openas2.support.FileMonitorAdapter.onFileEvent(FileMonitorAdapter.java:36)
buymore_1       | 	at org.openas2.support.FileMonitor.notifyListeners(FileMonitor.java:50)
buymore_1       | 	at org.openas2.support.FileMonitor.run(FileMonitor.java:58)
buymore_1       | 	at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Unknown Source)
buymore_1       | 	at java.base/java.util.concurrent.FutureTask.runAndReset(Unknown Source)
buymore_1       | 	at java.base/java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(Unknown Source)
buymore_1       | 	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(Unknown Source)
buymore_1       | 	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(Unknown Source)
buymore_1       | 	at java.base/java.lang.Thread.run(Unknown Source)
buymore_1       | Caused by: org.openas2.OpenAS2Exception: Partnership cannot be loaded because there is a configuration error: Buymore2Largemart
buymore_1       | 	at org.openas2.BaseSession.loadPartnershipPoller(BaseSession.java:160)
buymore_1       | 	at org.openas2.partner.XMLPartnershipFactory.loadPartnership(XMLPartnershipFactory.java:241)
buymore_1       | 	at org.openas2.partner.XMLPartnershipFactory.refreshConfig(XMLPartnershipFactory.java:131)
buymore_1       | 	... 11 more
buymore_1       | Caused by: org.openas2.OpenAS2Exception: Directory already being polled from config in partnership for the Buymore2Largemart partnership: /opt/openas2/data/outbox/AS2_ID_LARGEMART
buymore_1       | 	at org.openas2.BaseSession.checkPollerModuleConfig(BaseSession.java:123)
buymore_1       | 	at org.openas2.BaseSession.loadPartnershipPoller(BaseSession.java:153)
buymore_1       | 	... 13 more
```

If followed the call, directory pollers are destroyed in https://github.com/OpenAS2/OpenAs2App/blob/49aea86cb492ef84936cb95de5f7a5c6033d05da/Server/src/main/java/org/openas2/partner/XMLPartnershipFactory.java#L113 when the config is reloaded. But the `polledDirectories` map is cleared which leads to the exception being thrown in 

https://github.com/OpenAS2/OpenAs2App/blob/49aea86cb492ef84936cb95de5f7a5c6033d05da/Server/src/main/java/org/openas2/BaseSession.java#L120-L125

The fix in this PR solves the issue for me.

P.S.: I'm no Java dev, so I'm not sure if this is the optimal solution