### PR TITLE
set CLASSPATH in start-openas2.bat

### DIFF
--- a/Server/src/bin/start-openas2.bat
+++ b/Server/src/bin/start-openas2.bat
@@ -43,7 +43,7 @@ for /R %OPENAS2_BASE_DIR%/lib %%a in (*.jar) do (
 set LIB_JARS=".!LIB_JARS!"
 setLocal disableDelayedExpansion
 rem  Include the bin dir so that commons-logging.properties is found
-CLASSPATH=.;%LIB_JARS%;%OPENAS2_BASE_DIR%/bin
+set CLASSPATH=.;%LIB_JARS%;%OPENAS2_BASE_DIR%/bin
 rem echo Running: "%JAVA%" %EXTRA_PARMS%  -cp %CLASSPATH% org.openas2.app.OpenAS2Server "%OPENAS2_BASE_DIR%/config/config.xml"
 "%JAVA%" %EXTRA_PARMS%  -cp .;%LIB_JARS% org.openas2.app.OpenAS2Server "%OPENAS2_BASE_DIR%/config/config.xml"
 


### PR DESCRIPTION
The `set` command was missing before the CLASSPATH so that it generated a "command not found" message.