### PR TITLE
Fix high cpu consumption in RestCommandProcessor

### DIFF
--- a/Server/src/main/java/org/openas2/cmd/processor/RestCommandProcessor.java
+++ b/Server/src/main/java/org/openas2/cmd/processor/RestCommandProcessor.java
@@ -42,8 +42,13 @@ public class RestCommandProcessor extends BaseCommandProcessor {
     private HttpServer server;
 
     @Override
+    public void schedule(ScheduledExecutorService executor) throws OpenAS2Exception {
+        // Do nothing. Everything is set up in the method init.
+    } 
+
+    @Override
     public void processCommand() throws Exception {
-        //throw new UnsupportedOperationException("Commands received by HTTP Server thread");
+        // This method is never called because schedule is overriden.
     }
 
     public CommandResult feedCommand(String commandText, List<String> params) throws Exception {

--- a/Server/src/main/java/org/openas2/cmd/processor/RestCommandProcessor.java
+++ b/Server/src/main/java/org/openas2/cmd/processor/RestCommandProcessor.java
@@ -27,6 +27,7 @@ import java.io.IOException;
 import java.net.URI;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.ScheduledExecutorService;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import org.glassfish.jersey.message.filtering.EntityFilteringFeature;


### PR DESCRIPTION
RestCommandProcessor.processCommand() did nothing and BaseCommandProcessor.schedule called processCommand in an endless loop, resulting in a thread which continuously processed an endless loop.

By overriding schedule there is no loop any more.

Closes #283.