### PR TITLE
"ms" removed from logging of transfer time

### DIFF
--- a/Server/src/main/java/org/openas2/processor/sender/AS2SenderModule.java
+++ b/Server/src/main/java/org/openas2/processor/sender/AS2SenderModule.java
@@ -191,7 +191,7 @@ public class AS2SenderModule extends HttpSenderModule implements HasSchedule {
         boolean preventChunking = msg.getPartnership().isPreventChunking(false);
         ResponseWrapper resp = HTTPUtil.execRequest(HTTPUtil.Method.POST, url, ih, null, securedData.getInputStream(), httpOptions, maxSize, preventChunking);
         if (logger.isInfoEnabled()) {
-            logger.info("Message sent and response received in " + resp.getTransferTimeMs() + "ms" + msg.getLogMsgID());
+            logger.info("Message sent and response received in " + resp.getTransferTimeMs() + msg.getLogMsgID());
         }
 
         // Check the HTTP Response code


### PR DESCRIPTION
Logging shows: `Message sent and response received in 2804 millisecondsms`.

This commit removes the duplicate "ms" part.