### PR TITLE
Fix typo 'confog' to 'config'

### DIFF
--- a/Server/src/main/java/org/openas2/XMLSession.java
+++ b/Server/src/main/java/org/openas2/XMLSession.java
@@ -57,7 +57,7 @@ public class XMLSession extends BaseSession {
     private CommandRegistry commandRegistry;
     private CommandManager cmdManager = new CommandManager();
 
-    // Poller base confog that will be used for partnership based pollers. Can be overridden in the partnership
+    // Poller base config that will be used for partnership based pollers. Can be overridden in the partnership
     private Node basePollerConfigNode = null;
 
     private Attributes manifestAttributes = null;

--- a/changes.txt
+++ b/changes.txt
@@ -11,7 +11,7 @@ This is an enhancement and minor bugfix release:
 
   1. Fix message attributes not being available to partnership config (eg attributes.filename)
   2. Add defensie coding for highly questionnable file names sent by partner containing an asterisk such as ".*"
-  3. Further enhancements to the confog.xml extracting key values to properties to facilitate auto upgrades.
+  3. Further enhancements to the config.xml extracting key values to properties to facilitate auto upgrades.
   4. Enhance helper scripts to support non-prompting execution allowing invocation from other scripts.
   5. Disable the WebUI module by default as it only runs with Java 11 and above.
 


### PR DESCRIPTION
While reading the code and trying to figure out how it all worked, I noticed this typo.
