### PR TITLE
Set line endings to LF

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+* text=auto eol=lf
+


### PR DESCRIPTION
On Windows by default Git changes line endings locally to CR LF which makes scripts like mvnw fail when copied into the comntainer, see also: https://github.com/OpenAS2/OpenAs2App/issues/303

This settings forces Git to keep the LF line ending locally.