### PR TITLE
Fix resend failure to persist to errordir

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -1,19 +1,19 @@
 #              OpenAS2 Server
-#              Version 3.9.0
+#              Version 3.9.1
 #              RELEASE NOTES
 -----
-The OpenAS2 project is pleased to announce the release of OpenAS2 3.9.0
+The OpenAS2 project is pleased to announce the release of OpenAS2 3.9.1
 
-The release download file is: OpenAS2Server-3.9.0.zip
+The release download file is: OpenAS2Server-3.9.1.zip
 
 The zip file contains a PDF document (OpenAS2HowTo.pdf) providing information on installing and using the application.
 ## NOTE: Testing covers Java 8 to 17. The application should work for older versions down to Java 7 but they are not tested as part of the CI/CD pipeline.
 
-Version 3.9.0 - 2023-12-20
-This is an enhancement release:
+Version 3.9.1 - 2024-02-06
+This is a minor bugfix release:
        **IMPORTANT NOTE**: Please review upgrade notes below if you are upgrading
 
- 1. Support for non-standard algorithm strings for partners that do not conform to the RFC standard. See documentation section 7.2.1 "Signing"
+ 1. Fix persistence to errordir after all resend attempts fail.
 
 ##Upgrade Notes
  See the openAS2HowTo appendix for the general process on upgrading OpenAS2.

--- a/Remote/pom.xml
+++ b/Remote/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>net.sf.openas2</groupId>
         <artifactId>OpenAS2</artifactId>
-        <version>3.9.0</version>
+        <version>3.9.1</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/Server/pom.xml
+++ b/Server/pom.xml
@@ -7,7 +7,7 @@
         <!-- DO NOT CHANGE THIS "groupId" WITHOUT CHANGING XMLSession.getManifestAttributes.MANIFEST_VENDOR_ID_ATTRIB -->
         <groupId>net.sf.openas2</groupId>
         <artifactId>OpenAS2</artifactId>
-        <version>3.9.0</version>
+        <version>3.9.1</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/Server/src/main/java/org/openas2/processor/resender/DirectoryResenderModule.java
+++ b/Server/src/main/java/org/openas2/processor/resender/DirectoryResenderModule.java
@@ -190,6 +190,7 @@ public class DirectoryResenderModule extends BaseResenderModule {
                 } catch (OpenAS2Exception e) {
                     // Just log and ignore since it will have been handled upstream
                     logger.error("Error resending message", e);
+                    IOUtil.handleArchive(file, getParameter(PARAM_ERROR_DIRECTORY, true));
                 }
 
                 if (!file.delete()) { // Delete the file, sender will re-queue if the transmission fails again

--- a/changes.txt
+++ b/changes.txt
@@ -1,3 +1,9 @@
+Version 3.9.1 - 2024-02-06
+This is a minor bugfix release:
+       **IMPORTANT NOTE**: Please review upgrade notes in the RELEASE-NOTES.md if you are upgrading
+
+ 1. Fix persistence to errordir after all resend attempts fail.
+
 Version 3.9.0 - 2023-12-20
 This is an enhancement release:
        **IMPORTANT NOTE**: Please review upgrade notes in the RELEASE-NOTES.md if you are upgrading

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>net.sf.openas2</groupId>
     <artifactId>OpenAS2</artifactId>
-    <version>3.9.0</version>
+    <version>3.9.1</version>
     <name>OpenAS2</name>
     <packaging>pom</packaging>
 
@@ -120,7 +120,7 @@
             <dependency>
                 <groupId>org.junit.jupiter</groupId>
 		        <artifactId>junit-jupiter</artifactId>
-		        <version>5.10.1</version>
+		        <version>5.10.2</version>
                 <scope>test</scope>
             </dependency>
             <!-- https://mvnrepository.com/artifact/org.mockito/mockito-core -->
@@ -171,13 +171,13 @@
            <dependency>
                <groupId>com.fasterxml.jackson.core</groupId>
                <artifactId>jackson-databind</artifactId>
-               <version>2.16.0</version>
+               <version>2.16.1</version>
                <type>jar</type>
            </dependency>
 		   <dependency>
 		        <groupId>com.fasterxml.jackson.module</groupId>
 		        <artifactId>jackson-module-jaxb-annotations</artifactId>
-		        <version>2.16.0</version>
+		        <version>2.16.1</version>
 		   </dependency>
            <dependency>
                <groupId>org.glassfish.jersey.media</groupId>
@@ -209,7 +209,7 @@
             <dependency>
                 <groupId>io.sentry</groupId>
                 <artifactId>sentry</artifactId>
-                <version>7.1.0</version>
+                <version>7.3.0</version>
             </dependency>
         </dependencies>
     </dependencyManagement>


### PR DESCRIPTION
If all resend attemots fail, the message was deleted instead of being saved to the errordir.