### PR TITLE
Fix Ports and add volume bindings for Docker

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ $ docker run -it --rm openas2:latest
 You can test it by visiting `http://container-ip:10080` in a browser or, if you need access outside the host, on port 4080:
 
 ```console
-$ docker run -it --rm -p 4080:10080 -p 4081:10081 -p 8443:8443 openas2:latest
+$ docker run -it --rm -p 4080:10080 -p 4081:10081 -p 8443:8080 openas2:latest
 ```
 
 You can then go to `http://localhost:4080` or `http://host-ip:4080` in a browser (noting that it will return a 401 since there are no proper AS2 headers sent by the browser by default).
@@ -90,7 +90,7 @@ $ docker build -t openas2:latest .
 Run the OpenAS2 server, with its network set to "host", so that the WebUI can access the server.
 
 ```console
-$ docker run -it --rm --net=host -p 4080:10080 -p 4081:10081 -p 8443:8443 openas2:latest
+$ docker run -it --rm --net=host -p 4080:10080 -p 4081:10081 -p 8443:8080 openas2:latest
 ```
 
 In a separate terminal, build the WebUI docker image:

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ $ docker run -it --rm openas2:latest
 You can test it by visiting `http://container-ip:10080` in a browser or, if you need access outside the host, on port 4080:
 
 ```console
-$ docker run -it --rm -p 4080:10080 -p 4081:10081 -p 8443:8080 openas2:latest
+$ docker run -it --rm -p 4080:10080 -p 4081:10081 -p 8443:8080 -v ${PWD}/config:/opt/openas2/config -v ${PWD}/data:/opt/openas2/data openas2:latest
 ```
 
 You can then go to `http://localhost:4080` or `http://host-ip:4080` in a browser (noting that it will return a 401 since there are no proper AS2 headers sent by the browser by default).
@@ -90,7 +90,7 @@ $ docker build -t openas2:latest .
 Run the OpenAS2 server, with its network set to "host", so that the WebUI can access the server.
 
 ```console
-$ docker run -it --rm --net=host -p 4080:10080 -p 4081:10081 -p 8443:8080 openas2:latest
+$ docker run -it --rm --net=host -p 4080:10080 -p 4081:10081 -p 8443:8080 -v ${PWD}/config:/opt/openas2/config -v ${PWD}/data:/opt/openas2/data openas2:latest
 ```
 
 In a separate terminal, build the WebUI docker image:

--- a/README.md
+++ b/README.md
@@ -106,6 +106,9 @@ $ docker run --rm -p 8080:80 openas2_webui:latest
 ```
 
 Visit http://localhost:8080 and login with "userID" and "pWd".
+
+If the docker images are not locally installed you have to specify the full path at the Server field. (ex. http://192.168.1.100:8443/api) and either use a reverse proxy or allow connections from any location (config.xml restapi.command.processor.baseuri="http://0.0.0.0:8080").
+
 Note: You may have to login twice if you get a "Network Error" the first time.
 
 ## Docker Compose

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,6 +8,9 @@ services:
       - 4080:10080
       - 4081:10081
       - 8443:8080
+    volumes:
+      - ./config:/opt/openas2/config
+      - ./data:/opt/openas2/data
     tty: true
     stdin_open: true
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,7 @@ services:
     ports:
       - 4080:10080
       - 4081:10081
-      - 8443:8443
+      - 8443:8080
     tty: true
     stdin_open: true
 


### PR DESCRIPTION
Since the default listening port for the REST processor has been changed to 8080, so should the ports bindings of docker commands. I kept the host port to 8443 to prevent conflicts with the UI port also being in 8080.

I also added a note for the server field to prevent questions about not responding from remote.

Finally I added volume bindings for data and config folder, for easier configuration of docker images.