### PR TITLE
Allow config.xml parameters to be overridden with environment variables

### DIFF
--- a/Dockerfile_WebUI
+++ b/Dockerfile_WebUI
@@ -4,6 +4,8 @@ COPY ./WebUI /usr/src/webui
 WORKDIR /usr/src/webui
 RUN yarn install
 RUN npx browserslist@latest --update-db
+ARG VUE_APP_API_URL
+ENV VUE_APP_API_URL=${VUE_APP_API_URL:-http://localhost:8080}
 RUN yarn run build
 
 FROM nginx

--- a/README.md
+++ b/README.md
@@ -137,3 +137,38 @@ View specific container logs:
 $ docker compose logs openas2
 $ docker compose logs openas2_webui
 ```
+
+## Dynamically configure your container using environment variables
+
+Here is a short explaination how to override properties in the container's `config.xml` file using environment variables. 
+
+**Prerequisites:**
+
+* The container environment needs to have environment variables starting with the prefix `OPENAS2PROP_`.
+
+**Process:**
+
+1. **Start the container**: Start the container using your preferred method (e.g., Docker run command).
+2. **Environment variables take precedence**: The script running within the container (assumed to be `start-container.sh`) checks for the existence of `config.xml` in the `$OPENAS2_BASE/config` directory. 
+3. **Missing `config.xml`**: If `config.xml` is missing, the script:
+   - Copies the contents of the `config_template` directory into the `config` directory.
+4. **Missing `OPENAS2_PROPERTIES_FILE`**: If the `OPENAS2_PROPERTIES_FILE` is not found:
+   - The script logs a warning message using the defined colorized `echo_warn` function.
+   - It processes environment variables to generate properties file content.
+     - Environment variables starting with the prefix `OPENAS2PROP_` are considered.
+     - For each environment variable:
+       - The script removes the prefix using string manipulation.
+       - It replaces double underscores with dots (`__` to `.`) in the variable name.
+       - The name is converted to lowercase.
+       - The value of the environment variable is retrieved.
+       - The script logs the processed name and value with color using the `echo_ok` function.
+       - Finally, it writes the processed name and value in the format `"name=value"` to the `OPENAS2_PROPERTIES_FILE`.
+5. **Start OpenAS2**: After processing (if any), the script continues by calling the `start-openas2.sh` script located in the same directory to launch the OpenAS2 server.
+
+**Notes:**
+
+* This script provides a way to . 
+* Ensure the environment variables have appropriate access permissions and values within your container environment.
+* The script uses color-coded output (if the terminal supports it) to differentiate between warnings and successful operations. 
+* You can customize the color definitions or remove the colorization logic if not needed.
+* Remember to adjust the script path and variable names based on your specific container setup.

--- a/WebUI/README.md
+++ b/WebUI/README.md
@@ -12,6 +12,12 @@ This is a simple implementation of Web-based user interface that interacts with 
 yarn install
 ```
 
+### Environment Variables
+The OpenAS2 public REST api Endpoint needs to be configured with the VUE_APP_RESTAPI_URL env variable
+```
+VUE_APP_RESTAPI_URL=https://openas2/rest/api
+```
+
 ### Compiles and hot-reloads for development
 ```
 yarn run serve

--- a/WebUI/src/components/LoginScreen.vue
+++ b/WebUI/src/components/LoginScreen.vue
@@ -37,7 +37,7 @@ export default {
     data: function() {return {
         username: '',
         password: '',
-        server: 'http://127.0.0.1:8443/api',
+        server: process.env.VUE_APP_RESTAPI_URL || 'http://127.0.0.1:8443/api',
         rememberme: false,
         loading: false,
         errormsg: '',

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,18 +7,28 @@ services:
     ports:
       - 4080:10080
       - 4081:10081
-      - 8443:8080
-    volumes:
-      - ./config:/opt/openas2/config
-      - ./data:/opt/openas2/data
+      - ${HOST_RESTAPI_PORT:-8443}:8080
+    environment:
+      - OPENAS2PROP_RESTAPI__COMMAND__PROCESOR__BASEURI="http://0.0.0.0:8080"
+      - OPENAS2PROP_RESTAPI__COMMAND__PROCESOR__USERID="userID"
+      - OPENAS2PROP_RESTAPI__COMMAND__PROCESOR__PASSWORD="pWd"
     tty: true
     stdin_open: true
+    volumes:
+      - config:/opt/openas2/config:rw
+      - data:/opt/openas2/data:rw
+
 
   openas2_webui:
     build:
       context: .
       dockerfile: Dockerfile_WebUI
+      args:
+        - VUE_APP_RESTAPI_URL=http://localhost:${HOST_RESTAPI_PORT:-8443}/api
     ports:
-      - 8080:80
+      - ${HOST_WEBUI_PORT:-8080}:80
     tty: true
     stdin_open: true
+volumes:
+  config:
+  data:

--- a/start-container.sh
+++ b/start-container.sh
@@ -1,9 +1,53 @@
 #!/bin/sh
-
-if [ ! -e /opt/openas2/config/config.xml ]
-    then
-        echo "The config folder is empty, it will be populated by the template..."
-        cp -a config_template/* config/
-        echo "Done!"
+export OPENAS2_PROPERTIES_FILE=${OPENAS2_PROPERTIES_FILE:-$OPENAS2_BASE/config/openas2.properties}
+if [ $(tput colors) -ge 8 ]; then
+    RED=$(tput setaf 1)
+    GREEN=$(tput setaf 2)
+    NORMAL=$(tput sgr0)
 fi
+echo_warn() {
+    echo "${RED}${1}${NORMAL}"
+}
+echo_ok() {
+    echo "${GREEN}${1}${NORMAL}"
+}
+if [ ! -e $OPENAS2_BASE/config/config.xml ]
+    then
+        echo_warn "The config folder is empty, it will be populated by the template..."
+        cp -a $OPENAS2_BASE/config_template/* $OPENAS2_BASE/config/                
+        echo_ok "Done!"
+fi
+if [ ! -e $OPENAS2_PROPERTIES_FILE ]
+    then
+    echo_warn "Missing properties file" 
+    echo_ok "Processing Environment Variables into properties"    
+    # Define the prefix for matching environment variables
+    prefix="OPENAS2PROP_"
+
+    # Process each environment variable starting with the prefix
+    for env_var in $( env | grep "^${prefix}" | cut -d'=' -f1 )
+    do
+    if [ -z "$env_var" ]; then
+        continue
+    fi
+    
+    # Remove the prefix
+    modified_name="${env_var#${prefix}}"
+
+    # Replace double underscores with dots
+    modified_name=$( echo "${modified_name}" | sed 's/__/./g' )
+    
+  
+    # Convert to lowercase
+    modified_name=$( echo "$modified_name" | tr '[:upper:]' '[:lower:]' )
+
+    # Extract the value of the environment variable
+    value=$( eval "echo \"\$$env_var\"" )
+    echo "${GREEN}$modified_name=${NORMAL}${value}"
+    # Construct the properties command-line argument
+    echo "${modified_name}=${value}" >> $OPENAS2_PROPERTIES_FILE
+    done
+
+fi
+# Start OpenAS2 in foreground
 $(dirname $0)/start-openas2.sh


### PR DESCRIPTION
The default configuration listens on 127.0.0.1 internally in the docker container of OpenAS2 therefore the docker-compose port exposure doesn't route into it.

This pull request allows the config.xml parameters to be overridden with environment variables on the docker-compose.yml