### PR TITLE
Updating Dockerfile to more recent base images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,10 @@
-FROM openjdk:11 AS builder
+FROM eclipse-temurin:11.0.22_7-jdk-jammy AS builder
 COPY . /usr/src/openas2
 WORKDIR /usr/src/openas2
 # To test Locally builder environment:
 # docker run --rm -it -v $(pwd):/usr/src/openas2 openjdk:11 bash
+RUN apt update
+RUN apt-get install -y unzip
 RUN rm -f Server/dist/*
 RUN rm -f Remote/dist/*
 RUN rm -f Bundle/dist/*
@@ -16,7 +18,7 @@ RUN cd /usr/src/openas2/Runtime/bin && \
     mv config config_template
 
 
-FROM openjdk:11-jre-slim 
+FROM eclipse-temurin:11.0.22_7-jre-jammy
 ENV OPENAS2_BASE=/opt/openas2
 ENV OPENAS2_HOME=/opt/openas2
 ENV OPENAS2_TMPDIR=/opt/openas2/temp

--- a/Dockerfile_WebUI
+++ b/Dockerfile_WebUI
@@ -8,5 +8,5 @@ ARG VUE_APP_API_URL
 ENV VUE_APP_API_URL=${VUE_APP_API_URL:-http://localhost:8080}
 RUN yarn run build
 
-FROM nginx
+FROM nginx:stable-alpine
 COPY --from=web-builder /usr/src/webui/dist /usr/share/nginx/html


### PR DESCRIPTION
The used openjdk:11 package in the Dockerfile was last built 2 years ago and contains several vulnerabilities (see https://hub.docker.com/layers/library/openjdk/11-jre-slim/images/sha256-884c08d0f406a81ae1b5786932abaf399c335b997da7eea6a30cc51529220b66?context=explore).

Thus I have used eclipse-temurin:11.0.22_7-jre-jammy as a base which is actively supported.

I also switched to nginx_stable-alpine  for the WebUI dockerfile as it is smaller.