### PR TITLE
Improvement: Additional way to handle self-signed certificates if necessary

### DIFF
--- a/Server/src/main/java/org/openas2/util/HTTPUtil.java
+++ b/Server/src/main/java/org/openas2/util/HTTPUtil.java
@@ -33,6 +33,7 @@ import org.apache.http.ssl.SSLContexts;
 import org.openas2.OpenAS2Exception;
 import org.openas2.WrappedException;
 import org.openas2.message.Message;
+import org.openas2.processor.receiver.AS2ReceiverHandler;
 
 import jakarta.mail.Header;
 import jakarta.mail.MessagingException;
@@ -41,6 +42,9 @@ import javax.net.ssl.*;
 import java.io.*;
 import java.net.*;
 import java.security.KeyStore;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.security.cert.CertificateEncodingException;
 import java.security.cert.CertificateException;
 import java.security.cert.X509Certificate;
 import java.util.*;
@@ -66,6 +70,11 @@ public class HTTPUtil {
     public static final String HEADER_CONTENT_TYPE = "Content-Type";
     public static final String HEADER_USER_AGENT = "User-Agent";
     public static final String HEADER_CONNECTION = "Connection";
+
+    public static final String SSL_KEYSTORE_PATH_ENV = "SSL_KEYSTORE_PATH";
+    public static final String SSL_KEYSTORE_PASSWORD_ENV = "SSL_KEYSTORE_PASSWORD";
+    private static final ThreadLocal<Set<String>> trustedFingerprints = ThreadLocal.withInitial(HashSet::new);
+    private static final Logger LOG = LoggerFactory.getLogger(AS2ReceiverHandler.class);
 
     public abstract static class Method {
         public static final String GET = "GET";
@@ -397,35 +406,73 @@ public class HTTPUtil {
     }
 
     private static SSLConnectionSocketFactory buildSslFactory(URL urlObj, Map<String, String> options) throws Exception {
-
+        
+        boolean isCustomSelfSignedHandling = isCustomSelfSignedHandling();
         boolean overrideSslChecks = "true".equalsIgnoreCase(options.get(HTTPUtil.HTTP_PROP_OVERRIDE_SSL_CHECKS));
         SSLContext sslcontext;
         String selfSignedCN = System.getProperty("org.openas2.cert.TrustSelfSignedCN");
+
+        TrustManagerFactory tmf = TrustManagerFactory.getInstance(TrustManagerFactory.getDefaultAlgorithm());
+        X509TrustManager defaultTrustManager = null;
+
         if ((selfSignedCN != null && selfSignedCN.contains(urlObj.getHost())) || overrideSslChecks) {
+
             File file = getTrustedCertsKeystore();
             KeyStore ks = null;
             try (InputStream in = new FileInputStream(file)) {
                 ks = KeyStore.getInstance(KeyStore.getDefaultType());
                 ks.load(in, "changeit".toCharArray());
+                tmf.init(ks);
             }
             try {
                 // Trust own CA and all self-signed certs
                 sslcontext = SSLContexts.custom().loadTrustMaterial(ks, new TrustSelfSignedStrategy()).build();
+                defaultTrustManager = (X509TrustManager) tmf.getTrustManagers()[0];
                 // Allow TLSv1 protocol only by default
             } catch (Exception e) {
                 throw new OpenAS2Exception("Self-signed certificate URL connection failed connecting to : " + urlObj.toString(), e);
             }
+        } else if(isCustomSelfSignedHandling) {
+
+            KeyStore ks = getCustomKeyStore();
+            sslcontext = SSLContexts.custom().loadTrustMaterial(ks, new TrustSelfSignedStrategy()).build();
+            tmf.init(ks);
+            defaultTrustManager = (X509TrustManager) tmf.getTrustManagers()[0];
         } else {
             sslcontext = SSLContexts.createSystemDefault();
+            tmf.init((KeyStore) null);
+            defaultTrustManager = (X509TrustManager) tmf.getTrustManagers()[0];
         }
         // String [] protocols = Properties.getProperty(HTTP_PROP_SSL_PROTOCOLS,
         // "TLSv1").split("\\s*,\\s*");
         HostnameVerifier hnv = SSLConnectionSocketFactory.getDefaultHostnameVerifier();
+        SelfSignedTrustManager tm = new SelfSignedTrustManager(defaultTrustManager);
+        
         if (overrideSslChecks) {
             hnv = new HostnameVerifier() {
                 @Override
                 public boolean verify(String hostname, SSLSession session) {
                     return true;
+                }
+            };
+        } else if(isCustomSelfSignedHandling) {
+            hnv = new HostnameVerifier() {
+                @Override
+                public boolean verify(String hostname, SSLSession session) {
+                    try {
+                        // Check if the certificate's fingerprint is cached or if it exists in the custom keystore
+                        X509Certificate[] certs = (X509Certificate[]) session.getPeerCertificates();
+                        String fingerprint = tm.getCertificateFingerprint(certs[0]);
+        
+                        if (trustedFingerprints.get().contains(fingerprint) || tm.isCertificateInCustomKeystore(certs[0], fingerprint)) {
+                            LOG.info("Hostname verification skipped for trusted certificate: " + certs[0].getSubjectX500Principal().getName());
+                            return true;
+                        }
+                    } catch (Exception e) {
+                        LOG.error("Hostname verification failed: " + e.getMessage(), e);
+                    }
+
+                    return SSLConnectionSocketFactory.getDefaultHostnameVerifier().verify(hostname, session);
                 }
             };
         }
@@ -672,6 +719,22 @@ public class HTTPUtil {
                     } catch (Exception e) {
                         throw new OpenAS2Exception("Self-signed certificate URL connection failed connecting to : " + url, e);
                     }
+                } else if(isCustomSelfSignedHandling()) {
+                  try {
+                    KeyStore ks = getCustomKeyStore();
+                    SSLContext context = SSLContext.getInstance("TLS");
+                    TrustManagerFactory tmf = TrustManagerFactory.getInstance(TrustManagerFactory.getDefaultAlgorithm());
+                    tmf.init(ks);
+                    X509TrustManager defaultTrustManager = (X509TrustManager) tmf.getTrustManagers()[0];
+                    SelfSignedTrustManager tm = new SelfSignedTrustManager(defaultTrustManager);
+                    tm.setTrustCN(selfSignedCN);
+                    context.init(null, new TrustManager[]{tm}, null);
+                    connS.setSSLSocketFactory(context.getSocketFactory());
+    
+                  } catch (Exception e) {
+                    throw new OpenAS2Exception("Self-signed certificate URL connection failed connecting to : " + url, e);
+                  }
+                
                 }
                 conn = connS;
             } else {
@@ -681,13 +744,13 @@ public class HTTPUtil {
             conn.setDoInput(input);
             conn.setUseCaches(useCaches);
             conn.setRequestMethod(requestMethod);
-
+    
             return conn;
         } catch (IOException ioe) {
             throw new WrappedException("URL connection failed connecting to: " + url, ioe);
         }
     }
-
+    
     private static void setProxyConfig(HttpClientBuilder builder, RequestConfig.Builder rcBuilder, String protocol) throws OpenAS2Exception {
         String proxyHost = Properties.getProperty(protocol + ".proxyHost", null);
         if (proxyHost == null) {
@@ -806,6 +869,31 @@ public class HTTPUtil {
         }
     }
 
+    private static boolean isCustomSelfSignedHandling() {
+        return System.getenv(SSL_KEYSTORE_PATH_ENV) != null && System.getenv(SSL_KEYSTORE_PASSWORD_ENV) != null;
+    }
+
+    public static KeyStore getCustomKeyStore() throws OpenAS2Exception {
+
+        String keystorePath = System.getenv("SSL_KEYSTORE_PATH");
+        String keystorePassword = System.getenv("SSL_KEYSTORE_PASSWORD");
+    
+        LOG.info("Using environment variable for trust store path: " + keystorePath);
+    
+        if (keystorePath == null) {
+            throw new OpenAS2Exception("No trust store path set in environment variables");
+        }
+    
+        try (InputStream in = new FileInputStream(keystorePath)) {
+            KeyStore ks = KeyStore.getInstance(KeyStore.getDefaultType());
+            ks.load(in, keystorePassword.toCharArray());
+            LOG.info("Trust store loaded successfully from: " + keystorePath);
+            return ks;
+        } catch (Exception e) {
+            throw new OpenAS2Exception("Failed to load trust store from path: " + keystorePath, e);
+        }
+    }
+
     private static class SelfSignedTrustManager implements X509TrustManager {
 
         private final X509TrustManager tm;
@@ -824,8 +912,26 @@ public class HTTPUtil {
         }
 
         public void checkServerTrusted(X509Certificate[] chain, String authType) throws CertificateException {
+
             if (chain.length == 1) {
-                // Only ignore the check for self signed certs where CN (Canonical Name) matches
+                // check if certificate is in the truststore or is cached - IF SSL_KEYSTORE_PATH && SSL_KEYSTORE PASSWORD ARE SET
+                if(isCustomSelfSignedHandling()) {
+
+                    String fingerprint = getCertificateFingerprint(chain[0]);
+
+                    // Check if fingerprint is already cached to avoid re-opening keystore
+                    if (trustedFingerprints.get().contains(fingerprint)) {
+                        LOG.info("Certificate validation passed (cached) for " + chain[0].getSubjectX500Principal().getName());
+                        return;
+                    }
+            
+                    // Proceed with custom keystore handling if not cached
+                    if (isCustomSelfSignedHandling() && isCertificateInCustomKeystore(chain[0], fingerprint)) {
+                        LOG.info("Custom self-signed certificate validation passed for " + chain[0].getSubjectX500Principal().getName());
+                        return;
+                    }
+                } else {
+                // Only ignore the check for self signed certs where CN (Canonical Name) matches - DEFAULT BEHAVIOUR
                 String dn = chain[0].getIssuerX500Principal().getName();
                 for (int i = 0; i < trustCN.length; i++) {
                     if (dn.contains("CN=" + trustCN[i])) {
@@ -833,7 +939,36 @@ public class HTTPUtil {
                     }
                 }
             }
+        }
             tm.checkServerTrusted(chain, authType);
+        }
+
+        private String getCertificateFingerprint(X509Certificate cert) throws CertificateException {
+            try {
+                MessageDigest md = MessageDigest.getInstance("SHA-256");
+                byte[] fingerprintBytes = md.digest(cert.getEncoded());
+                StringBuilder sb = new StringBuilder();
+                for (byte b : fingerprintBytes) {
+                    sb.append(String.format("%02X", b));
+                }
+                return sb.toString();
+            } catch (NoSuchAlgorithmException | CertificateEncodingException e) {
+                throw new CertificateException("Failed to generate fingerprint for certificate", e);
+            }
+        }
+
+        private boolean isCertificateInCustomKeystore(X509Certificate cert, String fingerprint) {
+            try {
+                KeyStore keyStore = getCustomKeyStore();
+                String alias = keyStore.getCertificateAlias(cert);
+                if (alias != null) {
+                    trustedFingerprints.get().add(fingerprint); // Cache the fingerprint
+                    return true;
+                }
+            } catch (Exception e) {
+                LOG.error("Failed to verify certificate in custom keystore: " + e.getMessage(), e);
+            }
+            return false;
         }
 
         public void setTrustCN(String trustCN) {


### PR DESCRIPTION
Description

This pull request introduces an enhancement to HTTPUtil.java in OpenAS2 to improve handling of self-signed certificates. Previously, the only option for trusting self-signed certificates was the TrustSelfSignedCN system property, which is not ideal in most cases.

Problem Statement

In our setup, we must accept self-signed certificates from trading partners when sending messages to them. Additionally, in a Kubernetes environment, relying on system properties is cumbersome and inflexible. Configuring trusted self-signed certificates with TrustSelfSignedCN would require a Docker image rebuild whenever certificates change, limiting the ability to update certificates independently of the application image.

Solution

This update allows OpenAS2 to dynamically load trusted self-signed certificates from a keystore file specified by environment variables:

    SSL_KEYSTORE_PATH: Path to the keystore containing trusted certificates.
    SSL_KEYSTORE_PASSWORD: Password for the keystore.

With these environment variables set, HTTPUtil.java will bypass the need for TrustSelfSignedCN and use the specified keystore for SSL validation.

Changes Made

    Modified HTTPUtil.java to check if SSL_KEYSTORE_PATH and SSL_KEYSTORE_PASSWORD environment variables are set.
    If the environment variables are present, OpenAS2 loads the specified keystore and validates self-signed certificates against it.
    If the keystore contains a matching certificate, hostname verification is skipped, allowing the self-signed certificate to be trusted without rebuilding the image.

Benefits

    Kubernetes Compatibility: Enables dynamic, environment-based configuration without requiring image rebuilds.
    Improved Maintainability: Certificates can be updated by updating the keystore file mounted in the container, without modifying code or system properties.

Testing

This change has been tested in a Kubernetes environment to confirm that OpenAS2 dynamically reads the keystore and correctly validates self-signed certificates against it.

Summary

I just wanted to ask if there will be an update in the future that enhances the way self-signed certificates are handled in a more flexible manner, as the current TrustSelfSignedCN option was not sufficient for our needs.

In this pull request, I’ve introduced a solution that leverages environment variables to define the keystore path and password, making it possible to dynamically load trusted certificates without relying on system properties or requiring image rebuilds in Kubernetes environments.

Is this approach a good starting point, or is there a planned update that might handle self-signed certificates in an even more flexible way?
