### PR TITLE
Fix concurrent processing error

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -1,19 +1,19 @@
 #              OpenAS2 Server
-#              Version 4.6.2
+#              Version 4.6.3
 #              RELEASE NOTES
 -----
-The OpenAS2 project is pleased to announce the release of OpenAS2 4.6.2
+The OpenAS2 project is pleased to announce the release of OpenAS2 4.6.3
 
-The release download file is: OpenAS2Server-4.6.2.zip
+The release download file is: OpenAS2Server-4.6.3.zip
 
 The zip file contains a PDF document (OpenAS2HowTo.pdf) providing information on installing and using the application.
 ## NOTE: Testing covers Java 11 to 21.
 ##       Java 8 is NO LONGER SUPPORTED.
 
-Version 4.6.2 - 2025-09-27
+Version 4.6.3 - 2025-09-29
 
 This is a bugfix release.
-1. Enhanced the poller algorithm to avoid race conditions under very high volume file processing.
+1. Avoid  concurrent processing error that occurs after files after sent as part of the cleanup process.
 
 
 ##Upgrade Notes

--- a/Server/pom.xml
+++ b/Server/pom.xml
@@ -7,7 +7,7 @@
         <!-- DO NOT CHANGE THIS "groupId" WITHOUT CHANGING XMLSession.getManifestAttributes.MANIFEST_VENDOR_ID_ATTRIB -->
         <groupId>net.sf.openas2</groupId>
         <artifactId>OpenAS2</artifactId>
-        <version>4.6.2</version>
+        <version>4.6.3</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/changes.txt
+++ b/changes.txt
@@ -1,5 +1,10 @@
 **IMPORTANT NOTE**: Please review upgrade notes in the RELEASE-NOTES.md if you are upgrading
 
+Version 4.6.3 - 2025-09-29
+
+This is a bugfix release.
+1. Avoid  concurrent processing error that occurs after files after sent as part of the cleanup process.
+
 Version 4.6.2 - 2025-09-27
 
 This is a bugfix release.

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>net.sf.openas2</groupId>
     <artifactId>OpenAS2</artifactId>
-    <version>4.6.2</version>
+    <version>4.6.3</version>
     <name>OpenAS2</name>
     <packaging>pom</packaging>
 


### PR DESCRIPTION
Add a concurrent access safe list to track processed files and remove them as part of the update_tracking method flow.