### PR TITLE
Fix setting payload filename for generic poller

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -1,42 +1,33 @@
 #              OpenAS2 Server
+<<<<<<< HEAD
+#              Version 4.8.1
+#              RELEASE NOTES
+-----
+The OpenAS2 project is pleased to announce the release of OpenAS2 4.8.1
+
+The release download file is: OpenAS2Server-4.8.1.zip
+=======
 #              Version 4.8.0
 #              RELEASE NOTES
 -----
 The OpenAS2 project is pleased to announce the release of OpenAS2 4.8.0
 
 The release download file is: OpenAS2Server-4.8.0.zip
+>>>>>>> c180d9bd1ca4d43f23a850541de20e86c3fda27f
 
 The zip file contains a PDF document (OpenAS2HowTo.pdf) providing information on installing and using the application.
 ## NOTE: Testing covers Java 11 to 21.
 ##       Java 8 is NO LONGER SUPPORTED.
 
+<<<<<<< HEAD
+Version 4.8.1 - 2026-03-27
+=======
 Version 4.8.0 - 2025-10-31
+>>>>>>> c180d9bd1ca4d43f23a850541de20e86c3fda27f
 
 This is a minor bugfix release.
+1.  Correct payload filename when using generic directory poller.
 
-1.  Changes to partnership.xml
-
- * New optional attribute `quote_send_file_name` for the partnership to specify if
-   the filename which is to be included in header `Content-Disposition: Attachment; filename="filename.ext"` should be quoted or not.
-   Useful for target AS2 servers which are picky about the quotes. Requires `sendfilename="true"` to be set.  
-
-   Any value other than "false" will be considered true - default: true (previous behaviour).
-   ````
-   <!-- Configuration at partnership-level -->
-   <partnership name="MyCompany-to-PartnerA">
-       <sender name="MyCompany"/>
-       <receiver name="PartnerA"/>
-       <!-- ... -->
-   
-       <!-- Prerequisite: sendfilename has to be set -->
-       <!--  a) Set pollerConfigBase.sendfilename="true" in the config.xml OR -->
-       <!--  b) Set sendfilename="true" at partnership-level in the partnerships.xml using pollerConfig -->
-       <pollerConfig enabled="true" sendfilename="true"/>
-   
-       <!-- Example for disabling the quoting of the sent filename at partnership-level. -->
-       <attribute name="quote_send_file_name" value="false"/>
-   </partnership>
-   ````
 
 ## Upgrade Notes
  See the openAS2HowTo appendix for the general process on upgrading OpenAS2.

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -1,29 +1,17 @@
 #              OpenAS2 Server
-<<<<<<< HEAD
 #              Version 4.8.1
 #              RELEASE NOTES
 -----
 The OpenAS2 project is pleased to announce the release of OpenAS2 4.8.1
 
 The release download file is: OpenAS2Server-4.8.1.zip
-=======
-#              Version 4.8.0
-#              RELEASE NOTES
------
-The OpenAS2 project is pleased to announce the release of OpenAS2 4.8.0
-
-The release download file is: OpenAS2Server-4.8.0.zip
->>>>>>> c180d9bd1ca4d43f23a850541de20e86c3fda27f
 
 The zip file contains a PDF document (OpenAS2HowTo.pdf) providing information on installing and using the application.
 ## NOTE: Testing covers Java 11 to 21.
 ##       Java 8 is NO LONGER SUPPORTED.
 
-<<<<<<< HEAD
 Version 4.8.1 - 2026-03-27
 =======
-Version 4.8.0 - 2025-10-31
->>>>>>> c180d9bd1ca4d43f23a850541de20e86c3fda27f
 
 This is a minor bugfix release.
 1.  Correct payload filename when using generic directory poller.

--- a/Server/pom.xml
+++ b/Server/pom.xml
@@ -7,7 +7,7 @@
         <!-- DO NOT CHANGE THIS "groupId" WITHOUT CHANGING XMLSession.getManifestAttributes.MANIFEST_VENDOR_ID_ATTRIB -->
         <groupId>net.sf.openas2</groupId>
         <artifactId>OpenAS2</artifactId>
-        <version>4.8.0</version>
+        <version>4.8.1</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/Server/src/main/java/org/openas2/processor/receiver/MessageBuilderModule.java
+++ b/Server/src/main/java/org/openas2/processor/receiver/MessageBuilderModule.java
@@ -268,6 +268,7 @@ public abstract class MessageBuilderModule extends BaseReceiverModule {
         Message msg = createMessage();
         MessageParameters params = new MessageParameters(msg);
 
+        msg.setAttribute(FileAttribute.MA_FILENAME, filename);
         // Capture the original file name in case config changes it
         msg.setAttribute("original_filename", filename);
         // Get the parameter that should provide the link between the polled directory
@@ -289,12 +290,11 @@ public abstract class MessageBuilderModule extends BaseReceiverModule {
         // Should have sender/receiver now so update the message's partnership with any
         // stored information based on the identified partner IDs
         getSession().getPartnershipFactory().updatePartnership(msg, true);
+        msg.setPayloadFilename(msg.getAttribute(FileAttribute.MA_FILENAME));
         return msg;
     }
 
     public void addMessageMetadata(Message msg, String filename) throws OpenAS2Exception {
-        msg.setAttribute(FileAttribute.MA_FILENAME, filename);
-        msg.setPayloadFilename(filename);
         // Set the filename extension if it has one
         msg.setAttribute(FileAttribute.MA_FILENAME_EXTENSION, FileUtil.getFilenameExtension(filename));
         // Set a new message ID

--- a/changes.txt
+++ b/changes.txt
@@ -1,5 +1,13 @@
 **IMPORTANT NOTE**: Please review upgrade notes in the RELEASE-NOTES.md if you are upgrading
 
+<<<<<<< HEAD
+Version 4.8.1 - 2026-03-27
+
+This is a minor bugfix release.
+1.  Correct payload filename when using generic directory poller.
+
+=======
+>>>>>>> c180d9bd1ca4d43f23a850541de20e86c3fda27f
 Version 4.8.0 - 2025-10-31
 
 This is a minor enhancement release.

--- a/changes.txt
+++ b/changes.txt
@@ -1,13 +1,10 @@
 **IMPORTANT NOTE**: Please review upgrade notes in the RELEASE-NOTES.md if you are upgrading
 
-<<<<<<< HEAD
 Version 4.8.1 - 2026-03-27
 
 This is a minor bugfix release.
 1.  Correct payload filename when using generic directory poller.
 
-=======
->>>>>>> c180d9bd1ca4d43f23a850541de20e86c3fda27f
 Version 4.8.0 - 2025-10-31
 
 This is a minor enhancement release.

--- a/pom.xml
+++ b/pom.xml
@@ -5,11 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>net.sf.openas2</groupId>
     <artifactId>OpenAS2</artifactId>
-<<<<<<< HEAD
     <version>4.8.1</version>
-=======
-    <version>4.8.0</version>
->>>>>>> c180d9bd1ca4d43f23a850541de20e86c3fda27f
     <name>OpenAS2</name>
     <packaging>pom</packaging>
 

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,11 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>net.sf.openas2</groupId>
     <artifactId>OpenAS2</artifactId>
+<<<<<<< HEAD
+    <version>4.8.1</version>
+=======
     <version>4.8.0</version>
+>>>>>>> c180d9bd1ca4d43f23a850541de20e86c3fda27f
     <name>OpenAS2</name>
     <packaging>pom</packaging>
 
@@ -51,17 +55,17 @@
             <dependency>
                 <groupId>org.bouncycastle</groupId>
                 <artifactId>bcjmail-jdk18on</artifactId>
-                <version>1.82</version>
+                <version>1.83</version>
             </dependency>
             <dependency>
                 <groupId>org.bouncycastle</groupId>
                 <artifactId>bcpkix-jdk18on</artifactId>
-                <version>1.82</version>
+                <version>1.83</version>
             </dependency>
             <dependency>
                 <groupId>org.bouncycastle</groupId>
                 <artifactId>bcprov-jdk18on</artifactId>
-                <version>1.82</version>
+                <version>1.83</version>
             </dependency>
             <dependency>
                 <groupId>org.bouncycastle</groupId>
@@ -71,17 +75,17 @@
             <dependency>
                 <groupId>org.bouncycastle</groupId>
                 <artifactId>bcpg-jdk18on</artifactId>
-                <version>1.82</version>
+                <version>1.83</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.commons</groupId>
                 <artifactId>commons-lang3</artifactId>
-                <version>3.19.0</version>
+                <version>3.20.0</version>
             </dependency>
             <dependency>
                 <groupId>commons-cli</groupId>
                 <artifactId>commons-cli</artifactId>
-                <version>1.10.0</version>
+                <version>1.11.0</version>
             </dependency>
             <dependency>
                 <groupId>com.sun.mail</groupId>
@@ -116,14 +120,14 @@
                 <groupId>org.mockito</groupId>
                 <artifactId>mockito-core</artifactId>
 			    <!-- Hold at version 4.x for Java 8 compatibility -->
-			    <version>5.20.0</version>
+			    <version>5.23.0</version>
                 <scope>test</scope>
             </dependency>
 			<dependency>
 			    <groupId>org.mockito</groupId>
 			    <artifactId>mockito-junit-jupiter</artifactId>
 			    <!-- Hold at version 4.x for Java 8 compatibility -->
-			    <version>5.20.0</version>
+			    <version>5.23.0</version>
 			    <scope>test</scope>
 			</dependency>
 			<!-- https://mvnrepository.com/artifact/org.hamcrest/hamcrest -->
@@ -136,7 +140,7 @@
             <dependency>
                 <groupId>commons-io</groupId>
                 <artifactId>commons-io</artifactId>
-                <version>2.20.0</version>
+                <version>2.21.0</version>
             </dependency>
 			<dependency>
 			    <groupId>org.slf4j</groupId>
@@ -146,7 +150,7 @@
 			<dependency>
 			    <groupId>ch.qos.logback</groupId>
 			    <artifactId>logback-classic</artifactId>
-			    <version>1.5.19</version>
+			    <version>1.5.32</version>
 			</dependency>
 			<dependency>
 			    <groupId>jakarta.ws.rs</groupId>
@@ -167,13 +171,13 @@
            <dependency>
                <groupId>com.fasterxml.jackson.core</groupId>
                <artifactId>jackson-databind</artifactId>
-               <version>2.20.0</version>
+               <version>2.21.2</version>
                <type>jar</type>
            </dependency>
 		   <dependency>
 		        <groupId>com.fasterxml.jackson.module</groupId>
 		        <artifactId>jackson-module-jaxb-annotations</artifactId>
-		        <version>2.20.0</version>
+		        <version>2.21.2</version>
 		   </dependency>
            <dependency>
                <groupId>org.glassfish.jersey.media</groupId>
@@ -189,17 +193,17 @@
             <dependency>
                 <groupId>jakarta.xml.bind</groupId>
                 <artifactId>jakarta.xml.bind-api</artifactId>
-                <version>4.0.4</version>
+                <version>4.0.5</version>
             </dependency>
             <dependency>
                <groupId>com.sun.xml.bind</groupId>
                <artifactId>jaxb-core</artifactId>
-               <version>4.0.6</version>
+               <version>4.0.7</version>
            </dependency>
            <dependency>
                <groupId>com.sun.xml.bind</groupId>
                <artifactId>jaxb-impl</artifactId>
-               <version>4.0.6</version>
+               <version>4.0.7</version>
            </dependency>
 			<dependency>
 			   <groupId>com.zaxxer</groupId>


### PR DESCRIPTION
Fixes the bug where the sent payload file name is the full original file name instead of the parsed version extracted by the generic poller processing.