### PR TITLE
Fix container signal handling so the JVM receives SIGTERM for clean shutdown

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,4 +28,4 @@ COPY --from=builder /usr/src/openas2/Runtime/resources ${OPENAS2_BASE}/resources
 COPY --from=builder /usr/src/openas2/Runtime/config_template ${OPENAS2_HOME}/config_template
 RUN mkdir ${OPENAS2_BASE}/config
 WORKDIR $OPENAS2_HOME
-ENTRYPOINT ${OPENAS2_BASE}/bin/start-container.sh
+ENTRYPOINT ["/opt/openas2/bin/start-container.sh"]

--- a/Server/src/bin/start-openas2.sh
+++ b/Server/src/bin/start-openas2.sh
@@ -94,7 +94,8 @@ if [ "true" = "$OPENAS2_AS_DAEMON" ]; then
     echo $PID > $OPENAS2_PID
   fi
 else
-  ${CMD}
-  RETVAL="$?"
+  # Replace the shell with the java process so it receives signals directly
+  # (required for clean shutdown when running as PID 1 in a container)
+  exec ${CMD}
 fi
 exit $RETVAL

--- a/start-container.sh
+++ b/start-container.sh
@@ -49,5 +49,5 @@ if [ ! -e $OPENAS2_PROPERTIES_FILE ]
     done
 
 fi
-# Start OpenAS2 in foreground
-$(dirname $0)/start-openas2.sh
+# Start OpenAS2 in foreground, replacing this shell so signals reach the JVM
+exec $(dirname $0)/start-openas2.sh


### PR DESCRIPTION
## Problem

The Docker image's `ENTRYPOINT` uses the shell form, so PID 1 inside the container is `/bin/sh -c`, not the OpenAS2 JVM. `SIGTERM` sent by `docker stop` (or by Kubernetes on pod termination) is delivered to the shell, which does not forward it. As a result:

- The JVM's registered shutdown hook never runs — modules (including `DbTrackingModule` with the embedded H2 database) are never stopped cleanly.
- Every container stop waits out the full grace period (10s by default) and ends in `SIGKILL`.
- This is also what the Docker build check `JSONArgsRecommended` warns about on the current Dockerfile.

## Fix

Three small changes so the signal chain reaches the JVM:

1. **Dockerfile** — exec-form `ENTRYPOINT ["/opt/openas2/bin/start-container.sh"]` (exec form cannot expand variables; the path is already fixed by `ENV OPENAS2_BASE` in the same Dockerfile, and the scripts keep using the variable at runtime).
2. **start-container.sh** — `exec` the startup script instead of forking it.
3. **start-openas2.sh** — `exec` java in the foreground (non-daemon) branch so the JVM ends up as the final process. Daemon mode (`OPENAS2_AS_DAEMON=true`) is unchanged, and the exit code behavior of the foreground branch is preserved (`exec` makes the script's exit status the JVM's exit status).

## Verification (on the 4.8.2 image)

Before:
- `docker stop` takes **10.2s** (full grace period, then SIGKILL)
- No shutdown messages in the logs

After:
- `ps` inside the container shows **PID 1 = java**
- `docker stop` completes in **~0.2s**
- Logs show the shutdown hook running:
```
[Thread-0] INFO  org.openas2.processor.DefaultProcessor - DbTrackingModule stopped.
[Thread-0] INFO  org.openas2.processor.DefaultProcessor - AS2ReceiverModule stopped.
[Thread-0] INFO  org.openas2.processor.DefaultProcessor - AS2MDNReceiverModule stopped.
[Thread-0] INFO  org.openas2.processor.DefaultProcessor - DirectoryResenderModule stopped.
[Thread-0] INFO  org.openas2.processor.DefaultProcessor - 4 active module(s) stopped.
[Thread-0] INFO  org.openas2.app.OpenAS2Server - OpenAS2 has shut down
```

The `docker build` check warning `JSONArgsRecommended` is also gone.