### PR TITLE
Fix db_ddl.sql: align with authoritative openas2-schema.xml

### DIFF
--- a/Server/src/config/db_ddl.sql
+++ b/Server/src/config/db_ddl.sql
@@ -1,22 +1,25 @@
--- ----------------------------------------------------------------------- 
--- msg_metadata 
--- ----------------------------------------------------------------------- 
+-- -----------------------------------------------------------------------
+-- msg_metadata
+-- -----------------------------------------------------------------------
+-- This DDL must stay aligned with the authoritative schema in
+-- Server/src/resources/db/openas2-schema.xml. If you add/remove a column
+-- here, mirror the change in the XML (and vice versa).
 
 DROP TABLE msg_metadata IF EXISTS;
 
--- ----------------------------------------------------------------------- 
--- msg_metadata 
--- ----------------------------------------------------------------------- 
+-- -----------------------------------------------------------------------
+-- msg_metadata
+-- -----------------------------------------------------------------------
 
 CREATE TABLE msg_metadata
 (
     ID INTEGER NOT NULL AUTO_INCREMENT,
-    MSG_ID VARCHAR NOT NULL,
-    PRIOR_MSG_ID VARCHAR,
-    MDN_ID VARCHAR,
+    MSG_ID LONGVARCHAR NOT NULL,
+    PRIOR_MSG_ID LONGVARCHAR,
+    MDN_ID LONGVARCHAR,
     DIRECTION VARCHAR(25),
-    IS_RESEND VARCHAR(1),
-    RESEND_COUNT INTEGER,
+    IS_RESEND VARCHAR(1) DEFAULT 'N',
+    RESEND_COUNT INTEGER DEFAULT 0,
     SENDER_ID VARCHAR(255) NOT NULL,
     RECEIVER_ID VARCHAR(255) NOT NULL,
     STATUS VARCHAR(255),
@@ -25,15 +28,15 @@ CREATE TABLE msg_metadata
     ENCRYPTION_ALGORITHM VARCHAR(255),
     COMPRESSION VARCHAR(255),
     FILE_NAME VARCHAR(255),
+    SENT_FILE_NAME VARCHAR(255),
     CONTENT_TYPE VARCHAR(255),
     CONTENT_TRANSFER_ENCODING VARCHAR(255),
     MDN_MODE VARCHAR(255),
-    MDN_RESPONSE VARCHAR,
-    STATE_MSG VARCHAR,
-    CREATE_DT TIMESTAMP,
+    MDN_RESPONSE LONGVARCHAR,
+    STATE_MSG LONGVARCHAR,
+    CREATE_DT TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
     UPDATE_DT TIMESTAMP,
     PRIMARY KEY (ID)
 );
 
 CREATE UNIQUE INDEX MSG_ID_UNIQUE ON msg_metadata (MSG_ID);
-

--- a/Server/src/test/resources/config/db_ddl.sql
+++ b/Server/src/test/resources/config/db_ddl.sql
@@ -1,22 +1,25 @@
--- ----------------------------------------------------------------------- 
--- msg_metadata 
--- ----------------------------------------------------------------------- 
+-- -----------------------------------------------------------------------
+-- msg_metadata
+-- -----------------------------------------------------------------------
+-- This DDL must stay aligned with the authoritative schema in
+-- Server/src/resources/db/openas2-schema.xml. If you add/remove a column
+-- here, mirror the change in the XML (and vice versa).
 
 DROP TABLE msg_metadata IF EXISTS;
 
--- ----------------------------------------------------------------------- 
--- msg_metadata 
--- ----------------------------------------------------------------------- 
+-- -----------------------------------------------------------------------
+-- msg_metadata
+-- -----------------------------------------------------------------------
 
 CREATE TABLE msg_metadata
 (
     ID INTEGER NOT NULL AUTO_INCREMENT,
-    MSG_ID VARCHAR NOT NULL,
-    PRIOR_MSG_ID VARCHAR,
-    MDN_ID VARCHAR,
+    MSG_ID LONGVARCHAR NOT NULL,
+    PRIOR_MSG_ID LONGVARCHAR,
+    MDN_ID LONGVARCHAR,
     DIRECTION VARCHAR(25),
-    IS_RESEND VARCHAR(1),
-    RESEND_COUNT INTEGER,
+    IS_RESEND VARCHAR(1) DEFAULT 'N',
+    RESEND_COUNT INTEGER DEFAULT 0,
     SENDER_ID VARCHAR(255) NOT NULL,
     RECEIVER_ID VARCHAR(255) NOT NULL,
     STATUS VARCHAR(255),
@@ -25,15 +28,15 @@ CREATE TABLE msg_metadata
     ENCRYPTION_ALGORITHM VARCHAR(255),
     COMPRESSION VARCHAR(255),
     FILE_NAME VARCHAR(255),
+    SENT_FILE_NAME VARCHAR(255),
     CONTENT_TYPE VARCHAR(255),
     CONTENT_TRANSFER_ENCODING VARCHAR(255),
     MDN_MODE VARCHAR(255),
-    MDN_RESPONSE VARCHAR,
-    STATE_MSG VARCHAR,
-    CREATE_DT TIMESTAMP,
+    MDN_RESPONSE LONGVARCHAR,
+    STATE_MSG LONGVARCHAR,
+    CREATE_DT TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
     UPDATE_DT TIMESTAMP,
     PRIMARY KEY (ID)
 );
 
 CREATE UNIQUE INDEX MSG_ID_UNIQUE ON msg_metadata (MSG_ID);
-


### PR DESCRIPTION
## Summary

Aligns `Server/src/config/db_ddl.sql` with the authoritative schema in `Server/src/resources/db/openas2-schema.xml`. The two had drifted: most notably, `db_ddl.sql` was missing the `SENT_FILE_NAME` column that `DbTrackingModule` writes on every outbound, plus several other smaller divergences (column types, defaults).

Fixes the bug described in #537 (created alongside this PR).

## What's in the change

- **`SENT_FILE_NAME VARCHAR(255)`** added immediately after `FILE_NAME` (same position as in the XML).
- **`MSG_ID`, `PRIOR_MSG_ID`, `MDN_ID`, `MDN_RESPONSE`, `STATE_MSG`** promoted from unbounded `VARCHAR` to `LONGVARCHAR`, matching the XML.
- **Column defaults** added so the SQL matches the XML's behavior on fresh installs:
  - `IS_RESEND DEFAULT 'N'`
  - `RESEND_COUNT DEFAULT 0`
  - `CREATE_DT DEFAULT CURRENT_TIMESTAMP`
- **Header comment** added pointing maintainers at `openas2-schema.xml` as the single source of truth, so the two files don't drift again.
- **`Server/src/test/resources/config/db_ddl.sql`** mirrored with the same content to keep the test fixture aligned.

## Why this matters

`create_db_table.sh` (the "official" bootstrap path) needs Apache Ant on the host and TCP 9092 open on the H2 server. Hardened deployments routinely:

- skip ant (not on the runtime image), and
- set `tcp_server_start="false"` in `DbTrackingModule` so H2 stays in embedded/file mode (no exposed 9092).

In those deployments the only viable bootstrap is to apply `db_ddl.sql` directly via `org.h2.tools.RunScript` against the embedded `.mv.db` file. That's the path this PR fixes.

## Backwards compatibility

- Pure additive on the schema (one new column, defaults on existing columns, type widenings). No data migration needed for fresh installs.
- For existing installs that already created the table from the old `db_ddl.sql` and want to upgrade in place:
  ```sql
  ALTER TABLE msg_metadata ADD COLUMN sent_file_name VARCHAR(255);
  ```
  (`DbTrackingModule` inserts will work after this even without restarting.)

## How this was tested

- Bootstrapped a fresh H2 file with the new `db_ddl.sql` using `org.h2.tools.RunScript` on Debian 13 + OpenJDK 21.
- Sent an outbound message; `DbTrackingModule` wrote a complete row including `sent_file_name`.
- Smoke test repeated on a second independent deployment (same OS/JDK stack), same result.

## Notes for reviewers

- The XML schema (`openas2-schema.xml`) remains the source of truth; this PR just brings the convenience SQL up to date with it.
- A follow-up could consider auto-generating `db_ddl.sql` from the XML at build time so they cannot drift again. Out of scope for this PR — happy to do it as a second PR if maintainers prefer.
