### PR TITLE
Fix logging of error response body in AS2SenderModule

### DIFF
--- a/Server/src/main/java/org/openas2/processor/sender/AS2SenderModule.java
+++ b/Server/src/main/java/org/openas2/processor/sender/AS2SenderModule.java
@@ -201,7 +201,7 @@ public class AS2SenderModule extends HttpSenderModule implements HasSchedule {
         // Check the HTTP Response code
         int rc = resp.getStatusCode();
         if ((rc != HttpURLConnection.HTTP_OK) && (rc != HttpURLConnection.HTTP_CREATED) && (rc != HttpURLConnection.HTTP_ACCEPTED) && (rc != HttpURLConnection.HTTP_PARTIAL) && (rc != HttpURLConnection.HTTP_NO_CONTENT)) {
-            msg.setLogMsg("Error sending message. URL: " + url + " ::: Response Code: " + rc + " " + resp.getStatusPhrase() + " ::: Response Message: " + resp.getBody().toString());
+            msg.setLogMsg("Error sending message. URL: " + url + " ::: Response Code: " + rc + " " + resp.getStatusPhrase() + " ::: Response Message: " + new String(resp.getBody(), java.nio.charset.StandardCharsets.UTF_8));
             logger.error(msg.getLogMsg());
             throw new HttpResponseException(url, rc, resp.getStatusPhrase());
         }


### PR DESCRIPTION
## Fix HTTP error response body logging in AS2SenderModule

### Problem

When a partner returns a non-2xx HTTP response code, the error log message displays the raw Java byte array reference instead of the actual response body content.

Example of current broken output:
```
Error sending message. URL: https://partner.com:443/as2/incoming ::: Response Code: 500 Internal error. ::: Response Message: [B@24733dd5
```

This is caused by calling `.toString()` on the `byte[]` returned by `resp.getBody()`, which in Java outputs the type prefix `[B` and the object hash code rather than the string content.

### Fix

Replace `.toString()` with `new String(resp.getBody(), StandardCharsets.UTF_8)` to correctly decode the response body bytes into a readable string.

### Changes

`AS2SenderModule.java` — `sendMessage()` method:

```java
// Before
msg.setLogMsg("Error sending message. URL: " + url + " ::: Response Code: " + rc + " " + resp.getStatusPhrase() + " ::: Response Message: " + resp.getBody().toString());

// After
msg.setLogMsg("Error sending message. URL: " + url + " ::: Response Code: " + rc + " " + resp.getStatusPhrase() + " ::: Response Message: " + new String(resp.getBody(), java.nio.charset.StandardCharsets.UTF_8));
```

### Impact

No behavioral change — error handling and resend logic are unaffected. This only improves the content of the log message so that partner error responses are human-readable, which significantly aids in debugging failed transmissions.