### PR TITLE
Add JmsPollingModule: queue-based outbound sender

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -23,6 +23,7 @@ This is a minor enhancement and bugfix release.
 7. Add poller configuration to API command for partnership.
 8. Change the IOUtil moveFile method to a more intelligent algorithm for non-homogeneous moves.
 9. Add DbPartnershipFactory: partnerships can optionally be stored in a database (Azure SQL, PostgreSQL, MySQL, Oracle or the embedded H2) instead of the partnerships XML file. See the commented example in config.xml. The required tables are included in db_ddl.sql and openas2-schema.xml and are only needed when using the database partnership store.
+10. Add JmsPollingModule: an alternative outbound intake that consumes work from an AMQP 1.0 message queue (Azure Service Bus or any AMQP broker via Apache Qpid JMS) instead of polling a directory. An external producer publishes a queue message identifying the sender/receiver AS2 IDs and the file path; the file is sent through the existing pipeline and the broker owns retry/dead-lettering. See the commented example in config.xml.
 
 ## Upgrade Notes
  See the openAS2HowTo appendix for the general process on upgrading OpenAS2.

--- a/Server/pom.xml
+++ b/Server/pom.xml
@@ -228,6 +228,20 @@
             <groupId>com.h2database</groupId>
             <artifactId>h2</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.apache.qpid</groupId>
+            <artifactId>qpid-jms-client</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.activemq</groupId>
+            <artifactId>artemis-server</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.activemq</groupId>
+            <artifactId>artemis-amqp-protocol</artifactId>
+            <scope>test</scope>
+        </dependency>
 		<dependency>
 		   <groupId>com.zaxxer</groupId>
 		   <artifactId>HikariCP</artifactId>

--- a/Server/src/config/config.xml
+++ b/Server/src/config/config.xml
@@ -136,6 +136,35 @@
               format="sender.as2_id, receiver.as2_id, attributes.filename"
               mimetype="application/EDI-X12"/>
       -->
+      <!-- Alternative outbound intake that consumes work from a message queue instead of polling a
+           directory. It is a generic AMQP 1.0 JMS consumer (Apache Qpid JMS), so the same module
+           works against Azure Service Bus and any other AMQP 1.0 broker via the broker_url alone.
+           An external producer drops the file on shared storage and publishes a queue message that
+           sets string properties for the sender/receiver AS2 IDs (identify the partnership), the file
+           path and an optional filename. The property names default to sender_as2_id, receiver_as2_id,
+           filepath and filename, and can be overridden with the *_property attributes below.
+           The consumed file is sent through the same pipeline as the directory poller (identical signing,
+           encryption, MDN and tracking) and moved to the sent/error dir the same way. The broker is
+           the retry authority: on failure the message is redelivered and dead-lettered after the
+           broker's max delivery count.
+           consumer_count is the number of consumer threads per running instance (throughput), NOT
+           the high-availability mechanism: run multiple instances/pods against the same queue for
+           HA and failover (the broker shares the queue across them). Total outbound concurrency is
+           instances x consumer_count, so keep it within the connection limits your partners allow.
+      <module classname="org.openas2.processor.receiver.JmsPollingModule"
+              broker_url="amqps://your-namespace.servicebus.windows.net"
+              broker_user="$properties.servicebus.sas_key_name$"
+              broker_password="$properties.servicebus.sas_key$"
+              queue_name="outbound-as2"
+              consumer_count="1"
+              sender_id_property="sender_as2_id"
+              receiver_id_property="receiver_as2_id"
+              filepath_property="filepath"
+              filename_property="filename"
+              errordir="$properties.storageBaseDir$/outbox/error/$date.YYYY$-$date.MM$-$date.dd$"
+              sentdir="$properties.storageBaseDir$/sent"
+              mimetype="application/EDI-X12"/>
+      -->
       <module enabled="$properties.module.DbTrackingModule.enabled$"
               classname="org.openas2.processor.msgtracking.DbTrackingModule"
               use_embedded_db="$properties.msg_tracking.use_embedded_db$"

--- a/Server/src/main/java/org/openas2/processor/receiver/JmsPollingModule.java
+++ b/Server/src/main/java/org/openas2/processor/receiver/JmsPollingModule.java
@@ -1,0 +1,217 @@
+package org.openas2.processor.receiver;
+
+import jakarta.jms.Connection;
+import jakarta.jms.JMSException;
+import jakarta.jms.MessageConsumer;
+import jakarta.jms.MessageListener;
+import jakarta.jms.Queue;
+import jakarta.jms.Session;
+
+import org.apache.qpid.jms.JmsConnectionFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.openas2.OpenAS2Exception;
+import org.openas2.message.AS2Message;
+import org.openas2.message.Message;
+import org.openas2.partner.Partnership;
+
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.util.List;
+
+/**
+ * An alternative outbound intake to {@link AS2DirectoryPollingModule} that consumes work from a
+ * message queue instead of scanning a directory. It is a generic AMQP 1.0 JMS consumer (Apache
+ * Qpid JMS), so it works against Azure Service Bus and any other AMQP 1.0 broker via the connection
+ * URI alone.
+ * <p>
+ * The module is a pure consumer: an external producer drops the file on shared storage and
+ * publishes a queue message describing it. Each message carries, as JMS string properties, the
+ * sender and receiver AS2 IDs (used to resolve the partnership) and the path of the file to send.
+ * The module opens the file, then sends it through the same {@link MessageBuilderModule} pipeline
+ * the directory poller uses, so signing, encryption, MDN handling and tracking are identical. Files
+ * are moved to the sent/error directories exactly as the poller does.
+ * <p>
+ * Settlement mirrors the poller's file lifecycle and makes the broker the sole retry authority:
+ * per-message internal resend is disabled, so on a successful send (synchronous MDN received, or an
+ * asynchronous MDN send accepted and awaiting the callback) the message is acknowledged; on any
+ * failure it is returned to the broker for redelivery, which dead-letters it after the broker's
+ * configured maximum delivery count.
+ */
+public class JmsPollingModule extends MessageBuilderModule {
+
+    public static final String PARAM_BROKER_URL = "broker_url";
+    public static final String PARAM_QUEUE_NAME = "queue_name";
+    public static final String PARAM_BROKER_USER = "broker_user";
+    public static final String PARAM_BROKER_PWD = "broker_password";
+    public static final String PARAM_CONSUMER_COUNT = "consumer_count";
+    public static final String PARAM_SENDER_ID_PROPERTY = "sender_id_property";
+    public static final String PARAM_RECEIVER_ID_PROPERTY = "receiver_id_property";
+    public static final String PARAM_FILEPATH_PROPERTY = "filepath_property";
+    public static final String PARAM_FILENAME_PROPERTY = "filename_property";
+
+    // Default JMS message property names. JMS property names must be valid identifiers (no
+    // hyphens), so the AS2 IDs use underscore-separated names.
+    private static final String DEFAULT_SENDER_ID_PROPERTY = "sender_as2_id";
+    private static final String DEFAULT_RECEIVER_ID_PROPERTY = "receiver_as2_id";
+    private static final String DEFAULT_FILEPATH_PROPERTY = "filepath";
+    private static final String DEFAULT_FILENAME_PROPERTY = "filename";
+
+    private Connection connection = null;
+
+    private String queueName;
+    private String senderIdProperty;
+    private String receiverIdProperty;
+    private String filePathProperty;
+    private String filenameProperty;
+
+    // Carries the routing derived from the current message's properties into the shared
+    // buildBaseMessage() flow. Set and cleared within a single onMessage() call on the same thread.
+    private final ThreadLocal<String> currentRouting = new ThreadLocal<String>();
+
+    private Logger logger = LoggerFactory.getLogger(JmsPollingModule.class);
+
+    protected AS2Message createMessage() {
+        return new AS2Message();
+    }
+
+    /**
+     * Supplies per-message routing from the consumed queue message rather than the static
+     * "defaults" module parameter the directory poller uses.
+     */
+    @Override
+    protected String getSenderReceiverDefaults(Message msg) throws OpenAS2Exception {
+        return currentRouting.get();
+    }
+
+    /**
+     * Disables OpenAS2's internal file-based resend for queue-originated messages so the broker is
+     * the single retry authority. Setting the attribute on the message's own partnership copy only
+     * affects this send.
+     */
+    @Override
+    protected Message processDocument(File pendingFile, Message msg) throws OpenAS2Exception, FileNotFoundException {
+        msg.getPartnership().getAttributes().put(Partnership.PA_RESEND_MAX_RETRIES, "0");
+        return super.processDocument(pendingFile, msg);
+    }
+
+    public void doStart() throws OpenAS2Exception {
+        String brokerUrl = getParameter(PARAM_BROKER_URL, true);
+        queueName = getParameter(PARAM_QUEUE_NAME, true);
+        String user = getParameter(PARAM_BROKER_USER, false);
+        String pwd = getParameter(PARAM_BROKER_PWD, false);
+        int consumerCount = getParameterInt(PARAM_CONSUMER_COUNT, false, 1);
+        senderIdProperty = getParameter(PARAM_SENDER_ID_PROPERTY, DEFAULT_SENDER_ID_PROPERTY);
+        receiverIdProperty = getParameter(PARAM_RECEIVER_ID_PROPERTY, DEFAULT_RECEIVER_ID_PROPERTY);
+        filePathProperty = getParameter(PARAM_FILEPATH_PROPERTY, DEFAULT_FILEPATH_PROPERTY);
+        filenameProperty = getParameter(PARAM_FILENAME_PROPERTY, DEFAULT_FILENAME_PROPERTY);
+
+        try {
+            JmsConnectionFactory factory = new JmsConnectionFactory(brokerUrl);
+            connection = (user != null && user.length() > 0) ? factory.createConnection(user, pwd) : factory.createConnection();
+            connection.setExceptionListener(e -> logger.error("JMS connection error on queue " + queueName + ": " + e.getMessage(), e));
+            for (int i = 0; i < consumerCount; i++) {
+                // Transacted session so a failed send rolls back and is redelivered with an
+                // incremented delivery count, letting the broker dead-letter it after its
+                // configured maximum delivery count (portable across Artemis and Service Bus).
+                Session session = connection.createSession(true, Session.SESSION_TRANSACTED);
+                Queue queue = session.createQueue(queueName);
+                MessageConsumer consumer = session.createConsumer(queue);
+                consumer.setMessageListener(new QueueFileListener(session));
+            }
+            connection.start();
+            logger.info("JMS queue consumer started on queue \"" + queueName + "\" with " + consumerCount + " consumer(s)");
+        } catch (JMSException e) {
+            throw new OpenAS2Exception("Failed to start JMS queue consumer on queue: " + queueName, e);
+        }
+    }
+
+    public void doStop() throws OpenAS2Exception {
+        try {
+            if (connection != null) {
+                // Closing the connection closes its sessions and consumers
+                connection.close();
+            }
+        } catch (JMSException e) {
+            logger.error("Error closing JMS connection for queue " + queueName, e);
+        } finally {
+            connection = null;
+        }
+    }
+
+    @Override
+    public boolean healthcheck(List<String> failures) {
+        if (connection == null) {
+            failures.add(getClass().getSimpleName() + " - JMS connection is not established for queue: " + queueName);
+            return false;
+        }
+        return true;
+    }
+
+    private boolean isSendSuccessful(String state) {
+        return Message.MSG_STATE_MSG_SENT_MDN_RECEIVED_OK.equals(state)
+                || Message.MSG_STATE_MSG_SENT_AWAIT_ASYNC_MDN_RESPONSE.equals(state);
+    }
+
+    private class QueueFileListener implements MessageListener {
+        private final Session session;
+
+        QueueFileListener(Session session) {
+            this.session = session;
+        }
+
+        public void onMessage(jakarta.jms.Message jmsMessage) {
+            String filePath = null;
+            try {
+                filePath = jmsMessage.getStringProperty(filePathProperty);
+                String senderId = jmsMessage.getStringProperty(senderIdProperty);
+                String receiverId = jmsMessage.getStringProperty(receiverIdProperty);
+                if (filePath == null || senderId == null || receiverId == null) {
+                    throw new OpenAS2Exception("Queue message is missing required properties ("
+                            + filePathProperty + ", " + senderIdProperty + ", " + receiverIdProperty
+                            + "): filepath=" + filePath + " sender=" + senderId + " receiver=" + receiverId);
+                }
+                File file = new File(filePath);
+                String filename = jmsMessage.getStringProperty(filenameProperty);
+                if (filename == null || filename.length() == 0) {
+                    filename = file.getName();
+                }
+
+                currentRouting.set("sender.as2_id=" + senderId + ", receiver.as2_id=" + receiverId);
+
+                // Use the file-based intake so the original file is moved into the pipeline and
+                // ends up in the sent or error directory, matching the directory poller.
+                Message msg = processDocument(file, filename);
+                if (msg == null) {
+                    // Null is only returned when file-splitting kicks in, which writes the split
+                    // pieces to the source directory expecting a directory poller to pick them up.
+                    // That has no meaning for queue intake, so surface it rather than silently drop.
+                    throw new OpenAS2Exception("File splitting is not supported by the queue consumer for file: " + filePath);
+                }
+
+                String state = (String) msg.getOption("STATE");
+                if (isSendSuccessful(state)) {
+                    session.commit();
+                    if (logger.isInfoEnabled()) {
+                        logger.info("Queue message sent successfully (state=" + state + ") for file: " + filePath + msg.getLogMsgID());
+                    }
+                } else {
+                    // The file has already been moved to the error directory by the pipeline.
+                    // Roll back so the message is redelivered and eventually dead-lettered.
+                    logger.error("Send failed (state=" + state + ") for queue file: " + filePath
+                            + " - rolling back for redelivery/dead-lettering");
+                    session.rollback();
+                }
+            } catch (Exception e) {
+                logger.error("Failed to process queue message for file: " + filePath, e);
+                try {
+                    session.rollback();
+                } catch (JMSException je) {
+                    logger.error("Failed to roll back after processing error for file: " + filePath, je);
+                }
+            } finally {
+                currentRouting.remove();
+            }
+        }
+    }
+}

--- a/Server/src/main/java/org/openas2/processor/receiver/MessageBuilderModule.java
+++ b/Server/src/main/java/org/openas2/processor/receiver/MessageBuilderModule.java
@@ -271,9 +271,9 @@ public abstract class MessageBuilderModule extends BaseReceiverModule {
         msg.setAttribute(FileAttribute.MA_FILENAME, filename);
         // Capture the original file name in case config changes it
         msg.setAttribute("original_filename", filename);
-        // Get the parameter that should provide the link between the polled directory
+        // Get the parameter that should provide the link between the source of the file
         // and an AS2 sender and recipient
-        String defaults = getParameter(PARAM_DEFAULTS, false);
+        String defaults = getSenderReceiverDefaults(msg);
         // Link the file to an AS2 sender and recipient via the Message object
         // associated with the file
         if (defaults != null) {
@@ -292,6 +292,20 @@ public abstract class MessageBuilderModule extends BaseReceiverModule {
         getSession().getPartnershipFactory().updatePartnership(msg, true);
         msg.setPayloadFilename(msg.getAttribute(FileAttribute.MA_FILENAME));
         return msg;
+    }
+
+    /**
+     * Resolves the "defaults" string (e.g. "sender.as2_id=X, receiver.as2_id=Y") that links a
+     * source file to an AS2 sender and receiver. The default implementation returns the static
+     * {@value #PARAM_DEFAULTS} module parameter used by directory pollers. Intake modules that
+     * carry per-message routing (e.g. a queue consumer reading message properties) override this
+     * to supply routing for the specific message being built.
+     *
+     * @param msg - the message being built (available for subclasses that derive routing from it)
+     * @return the defaults string, or null if none applies
+     */
+    protected String getSenderReceiverDefaults(Message msg) throws OpenAS2Exception {
+        return getParameter(PARAM_DEFAULTS, false);
     }
 
     public void addMessageMetadata(Message msg, String filename) throws OpenAS2Exception {

--- a/Server/src/test/java/org/openas2/processor/receiver/JmsPollingModuleTest.java
+++ b/Server/src/test/java/org/openas2/processor/receiver/JmsPollingModuleTest.java
@@ -1,0 +1,260 @@
+package org.openas2.processor.receiver;
+
+import jakarta.jms.Connection;
+import jakarta.jms.MessageProducer;
+import jakarta.jms.Queue;
+import jakarta.jms.Session;
+
+import org.apache.activemq.artemis.api.core.SimpleString;
+import org.apache.activemq.artemis.core.config.Configuration;
+import org.apache.activemq.artemis.core.config.impl.ConfigurationImpl;
+import org.apache.activemq.artemis.core.server.embedded.EmbeddedActiveMQ;
+import org.apache.activemq.artemis.core.settings.impl.AddressSettings;
+import org.apache.qpid.jms.JmsConnectionFactory;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Assumptions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.TestInstance.Lifecycle;
+import org.junit.jupiter.api.io.TempDir;
+import org.openas2.OpenAS2Exception;
+import org.openas2.message.AS2Message;
+import org.openas2.message.Message;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.ServerSocket;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Exercises JmsPollingModule against a real embedded AMQP 1.0 broker (ActiveMQ Artemis) via the
+ * Qpid JMS client. Verifies that a published queue message is consumed, routed using its
+ * properties, and settled correctly: acknowledged on a successful send, and returned to the broker
+ * for redelivery and dead-lettering on failure. The actual AS2 send is stubbed by overriding
+ * processDocument so the test isolates the queue-consumer and settlement behaviour.
+ */
+@TestInstance(Lifecycle.PER_CLASS)
+public class JmsPollingModuleTest {
+
+    private static final String DLQ = "DLQ";
+    private static final int MAX_DELIVERY_ATTEMPTS = 2;
+
+    private EmbeddedActiveMQ broker;
+    private String brokerUrl;
+
+    @TempDir
+    Path tempDir;
+
+    private CapturingJmsPollingModule module;
+    // A unique queue per test so a consumer still closing from a prior test cannot interfere
+    private final AtomicInteger queueSeq = new AtomicInteger();
+    private String queue;
+
+    @BeforeAll
+    public void startBroker() throws Exception {
+        int port;
+        try (ServerSocket s = new ServerSocket(0)) {
+            port = s.getLocalPort();
+        }
+        brokerUrl = "amqp://localhost:" + port;
+
+        Configuration config = new ConfigurationImpl()
+                .setPersistenceEnabled(false)
+                .setSecurityEnabled(false)
+                .addAcceptorConfiguration("amqp", "tcp://localhost:" + port + "?protocols=AMQP");
+
+        // Redeliver failed messages a bounded number of times, then dead-letter them
+        AddressSettings settings = new AddressSettings()
+                .setMaxDeliveryAttempts(MAX_DELIVERY_ATTEMPTS)
+                .setDeadLetterAddress(SimpleString.of(DLQ))
+                .setAutoCreateQueues(true)
+                .setAutoCreateAddresses(true);
+        config.addAddressSetting("#", settings);
+
+        broker = new EmbeddedActiveMQ();
+        broker.setConfiguration(config);
+        boolean active = false;
+        try {
+            broker.start();
+            // On some JREs (e.g. Java 24+, where Artemis calls the removed Subject.getSubject())
+            // initialisation fails and is logged without throwing, leaving the server inactive and
+            // its acceptor unbound. Poll for the server to actually become active.
+            for (int i = 0; i < 30 && !active; i++) {
+                active = broker.getActiveMQServer() != null && broker.getActiveMQServer().isActive();
+                if (!active) {
+                    Thread.sleep(100);
+                }
+            }
+        } catch (Throwable t) {
+            // fall through: handled by the assumption below
+        }
+        // Skip (rather than fail) when the test broker cannot run on this JRE. This is a limitation
+        // of the embedded Artemis test broker, not of the module under test, which is JRE-agnostic.
+        Assumptions.assumeTrue(active, "Embedded AMQP broker could not start on this JRE (test broker limitation)");
+    }
+
+    @AfterAll
+    public void stopBroker() throws Exception {
+        if (broker != null) {
+            try {
+                broker.stop();
+            } catch (Exception ignored) {
+                // broker may not have started on this JRE
+            }
+        }
+    }
+
+    @BeforeEach
+    public void perTestSetup() throws Exception {
+        queue = "outbound-as2-" + queueSeq.incrementAndGet();
+        // Ensure each test starts with an empty DLQ
+        receiveFrom(DLQ, 200);
+    }
+
+    private void startModule(String successOrFailState) throws Exception {
+        module = new CapturingJmsPollingModule();
+        module.stateToReturn = successOrFailState;
+        Map<String, String> params = new HashMap<String, String>();
+        params.put(JmsPollingModule.PARAM_BROKER_URL, brokerUrl);
+        params.put(JmsPollingModule.PARAM_QUEUE_NAME, queue);
+        module.init(null, params);
+        module.start();
+    }
+
+    private void stopModule() throws Exception {
+        if (module != null) {
+            module.stop();
+            module = null;
+        }
+    }
+
+    private Path publishMessage(String sender, String receiver, String content) throws Exception {
+        Path file = Files.createTempFile(tempDir, "payload", ".edi");
+        Files.write(file, content.getBytes());
+        JmsConnectionFactory factory = new JmsConnectionFactory(brokerUrl);
+        try (Connection conn = factory.createConnection()) {
+            Session session = conn.createSession(false, Session.AUTO_ACKNOWLEDGE);
+            Queue jmsQueue = session.createQueue(queue);
+            MessageProducer producer = session.createProducer(jmsQueue);
+            jakarta.jms.Message m = session.createMessage();
+            m.setStringProperty("sender_as2_id", sender);
+            m.setStringProperty("receiver_as2_id", receiver);
+            m.setStringProperty("filepath", file.toString());
+            m.setStringProperty("filename", file.getFileName().toString());
+            producer.send(m);
+        }
+        return file;
+    }
+
+    private jakarta.jms.Message receiveFrom(String queueName, long timeoutMs) throws Exception {
+        JmsConnectionFactory factory = new JmsConnectionFactory(brokerUrl);
+        try (Connection conn = factory.createConnection()) {
+            conn.start();
+            Session session = conn.createSession(false, Session.AUTO_ACKNOWLEDGE);
+            Queue queue = session.createQueue(queueName);
+            return session.createConsumer(queue).receive(timeoutMs);
+        }
+    }
+
+    private void awaitProcessCount(int expected, long timeoutMs) throws InterruptedException {
+        long deadline = System.currentTimeMillis() + timeoutMs;
+        while (System.currentTimeMillis() < deadline) {
+            if (module.processCount.get() >= expected) {
+                return;
+            }
+            Thread.sleep(50);
+        }
+    }
+
+    @Test
+    public void successfulSendAcknowledgesAndRoutesByProperties() throws Exception {
+        startModule(Message.MSG_STATE_MSG_SENT_MDN_RECEIVED_OK);
+        try {
+            Path file = publishMessage("MyCompany_OID", "PartnerA_OID", "EDI payload body");
+            awaitProcessCount(1, 5000);
+
+            assertEquals(1, module.processCount.get(), "message should be consumed exactly once");
+            assertEquals("sender.as2_id=MyCompany_OID, receiver.as2_id=PartnerA_OID", module.capturedRouting);
+            assertEquals(file.getFileName().toString(), module.capturedFilename);
+            assertEquals("EDI payload body", new String(module.capturedContent));
+
+            // Acknowledged, so it must not be redelivered or dead-lettered
+            Thread.sleep(300);
+            assertEquals(1, module.processCount.get(), "acknowledged message must not be redelivered");
+            assertNull(receiveFrom(DLQ, 500), "successful message must not be dead-lettered");
+        } finally {
+            stopModule();
+        }
+    }
+
+    @Test
+    public void asyncMdnAwaitStateIsTreatedAsSuccess() throws Exception {
+        startModule(Message.MSG_STATE_MSG_SENT_AWAIT_ASYNC_MDN_RESPONSE);
+        try {
+            publishMessage("MyCompany_OID", "PartnerA_OID", "async body");
+            awaitProcessCount(1, 5000);
+
+            Thread.sleep(300);
+            assertEquals(1, module.processCount.get(), "async-await send must be acknowledged, not redelivered");
+            assertNull(receiveFrom(DLQ, 500), "async-await send must not be dead-lettered");
+        } finally {
+            stopModule();
+        }
+    }
+
+    @Test
+    public void failedSendIsRedeliveredThenDeadLettered() throws Exception {
+        startModule(Message.MSG_STATE_SEND_FAIL);
+        try {
+            publishMessage("MyCompany_OID", "PartnerA_OID", "will fail");
+            // Redelivered up to the broker's max delivery attempts, then routed to the DLQ
+            awaitProcessCount(MAX_DELIVERY_ATTEMPTS, 8000);
+
+            assertEquals(MAX_DELIVERY_ATTEMPTS, module.processCount.get(),
+                    "failed message should be delivered exactly max-delivery-attempts times");
+            jakarta.jms.Message dead = receiveFrom(DLQ, 3000);
+            assertNotNull(dead, "failed message should end up on the dead-letter queue");
+            assertEquals("MyCompany_OID", dead.getStringProperty("sender_as2_id"));
+        } finally {
+            stopModule();
+        }
+    }
+
+    /**
+     * Test module that stubs the AS2 send: it records what was consumed and returns a message with
+     * a configurable final STATE so the settlement logic can be exercised deterministically.
+     */
+    private static class CapturingJmsPollingModule extends JmsPollingModule {
+        volatile String stateToReturn;
+        volatile String capturedRouting;
+        volatile String capturedFilename;
+        volatile byte[] capturedContent;
+        final AtomicInteger processCount = new AtomicInteger();
+
+        @Override
+        protected Message processDocument(File fileToSend, String filename) throws OpenAS2Exception {
+            processCount.incrementAndGet();
+            capturedFilename = filename;
+            capturedRouting = getSenderReceiverDefaults(null);
+            try {
+                capturedContent = Files.readAllBytes(fileToSend.toPath());
+            } catch (IOException e) {
+                throw new OpenAS2Exception(e);
+            }
+            AS2Message msg = new AS2Message();
+            msg.setOption("STATE", stateToReturn);
+            return msg;
+        }
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -93,6 +93,26 @@
                 <artifactId>h2</artifactId>
                 <version>2.4.240</version>
             </dependency>
+            <!-- AMQP 1.0 JMS client for the queue-based sender module (Azure Service Bus and any AMQP broker).
+                 Qpid JMS 2.x uses the jakarta.jms namespace to match the rest of the jakarta.* stack. -->
+            <dependency>
+                <groupId>org.apache.qpid</groupId>
+                <artifactId>qpid-jms-client</artifactId>
+                <version>2.6.1</version>
+            </dependency>
+            <!-- Embedded AMQP 1.0 broker for testing the queue module against a real broker. -->
+            <dependency>
+                <groupId>org.apache.activemq</groupId>
+                <artifactId>artemis-server</artifactId>
+                <version>2.37.0</version>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.activemq</groupId>
+                <artifactId>artemis-amqp-protocol</artifactId>
+                <version>2.37.0</version>
+                <scope>test</scope>
+            </dependency>
             <!-- https://mvnrepository.com/artifact/org.apache.httpcomponents/httpcore -->
             <dependency>
                 <groupId>org.apache.httpcomponents</groupId>


### PR DESCRIPTION
Adds a generic AMQP 1.0 JMS consumer (Apache Qpid JMS) as an alternative outbound intake to AS2DirectoryPollingModule. Works against any AMQP 1.0 broker via the broker_url alone.

An external producer drops the file on shared storage and publishes a queue message whose string properties carry the sender/receiver AS2 IDs and the file path. The consumed file is moved into the existing MessageBuilderModule pipeline (identical signing, encryption, MDN and tracking) and ends up in the sent or error directory exactly like the directory poller.

- Reuses processDocument(File) so the original file is moved (not copied) into the pipeline, matching AS2DirectoryPollingModule behaviour.
- Per-message routing is injected via a new overridable getSenderReceiverDefaults hook on MessageBuilderModule (default behaviour for the directory poller is unchanged).
- Transacted JMS sessions: commit on a successful send (sync MDN received, or async MDN send accepted), roll back on failure so the broker redelivers and dead-letters after its max delivery count. Internal file-based resend is disabled per-message so the broker is the sole retry authority.
- File splitting is not supported for queue intake and fails loudly.

Tested with unit tests against an embedded ActiveMQ Artemis broker plus a live OpenAS2 run verifying successful send (file moved to sent dir) and failure (file moved to error dir, message dead-lettered).