### PR TITLE
fix(webui): read REST API URL at runtime instead of build time

### DIFF
--- a/Dockerfile_WebUI
+++ b/Dockerfile_WebUI
@@ -10,3 +10,7 @@ RUN yarn run build
 
 FROM nginx:stable-alpine
 COPY --from=web-builder /usr/src/webui/dist /usr/share/nginx/html
+# Set at container start, not build time, so one image serves any deployment.
+ENV OPENAS2_RESTAPI_URL=http://localhost:8443/api
+COPY ./WebUI/docker/40-openas2-config.sh /docker-entrypoint.d/40-openas2-config.sh
+RUN chmod +x /docker-entrypoint.d/40-openas2-config.sh

--- a/WebUI/docker/40-openas2-config.sh
+++ b/WebUI/docker/40-openas2-config.sh
@@ -1,0 +1,15 @@
+#!/bin/sh
+# Regenerate the runtime config the WebUI reads before booting.
+# Runs automatically: nginx's entrypoint sources /docker-entrypoint.d/*.sh.
+set -e
+
+: "${OPENAS2_RESTAPI_URL:=http://localhost:8443/api}"
+
+# Escape backslashes and double quotes so the URL is a safe JS string literal.
+escaped=$(printf '%s' "$OPENAS2_RESTAPI_URL" | sed -e 's/\\/\\\\/g' -e 's/"/\\"/g')
+
+cat > /usr/share/nginx/html/config.js <<EOF
+window.__OPENAS2_CONFIG__ = { restApiUrl: "${escaped}" };
+EOF
+
+echo "openas2-webui: REST API URL set to ${OPENAS2_RESTAPI_URL}"

--- a/WebUI/public/config.js
+++ b/WebUI/public/config.js
@@ -1,0 +1,5 @@
+// Runtime configuration, loaded before the app bundle.
+// In a container this file is regenerated at startup by
+// docker-entrypoint.d/40-openas2-config.sh from OPENAS2_RESTAPI_URL.
+// An empty value falls through to the build-time default.
+window.__OPENAS2_CONFIG__ = { restApiUrl: "" };

--- a/WebUI/public/index.html
+++ b/WebUI/public/index.html
@@ -14,6 +14,7 @@
       <strong>We're sorry but openas2ui doesn't work properly without JavaScript enabled. Please enable it to continue.</strong>
     </noscript>
     <div id="app"></div>
+    <script src="<%= BASE_URL %>config.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.7.1/jquery.min.js" integrity="sha512-v2CJ7UaYy4JwqLDIrZUI/4hqeoQieOmAZNXBeQyjo21dadnwR+8ZaIJVT8EE2iyI61OV8e6M8PP2/4hpQINQ/g==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/2.11.8/umd/popper.min.js" integrity="sha512-TPh2Oxlg1zp+kz3nFA0C5vVC6leG/6mm1z9+mA81MI5eaUVqasPLO8Cuk4gMF4gUfP5etR73rgU/8PNMsSesoQ==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/bootstrap/5.3.3/js/bootstrap.min.js" integrity="sha512-ykZ1QQr0Jy/4ZkvKuqWn4iF3lqPZyij9iRv6sGqLRdTPkY69YX6+7wvVGmsdBbiIfN/8OdsI7HABjvEok6ZopQ==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>

--- a/WebUI/src/components/LoginScreen.vue
+++ b/WebUI/src/components/LoginScreen.vue
@@ -37,7 +37,11 @@ export default {
     data: function() {return {
         username: '',
         password: '',
-        server: process.env.VUE_APP_RESTAPI_URL || 'http://127.0.0.1:8443/api',
+        // Runtime config (config.js) wins so one image can serve any deployment,
+        // then the build-time value, then a local dev default.
+        server: (window.__OPENAS2_CONFIG__ && window.__OPENAS2_CONFIG__.restApiUrl)
+            || process.env.VUE_APP_RESTAPI_URL
+            || 'http://127.0.0.1:8443/api',
         rememberme: false,
         loading: false,
         errormsg: '',

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,8 +23,8 @@ services:
     build:
       context: .
       dockerfile: Dockerfile_WebUI
-      args:
-        - VUE_APP_RESTAPI_URL=http://localhost:${HOST_RESTAPI_PORT:-8443}/api
+    environment:
+      - OPENAS2_RESTAPI_URL=http://localhost:${HOST_RESTAPI_PORT:-8443}/api
     ports:
       - ${HOST_WEBUI_PORT:-8080}:80
     tty: true


### PR DESCRIPTION
## Problem

`VUE_APP_RESTAPI_URL` is read via `process.env` in `LoginScreen.vue`, which Vue CLI
inlines as a string literal at compile time. The REST API URL is therefore baked
into the JS bundle when the image is built.

The practical effect is that a published `Dockerfile_WebUI` image only ever works
against whatever host it was built for. It defaults to `http://localhost:8080`, so
anyone pulling a prebuilt WebUI image has to rebuild it from source just to point
the UI at their own server. That makes the WebUI image hard to distribute.

## Change

Serve the value from a small `config.js` loaded before the app bundle, and
regenerate that file at container start from an environment variable.

- `WebUI/public/config.js` — sets `window.__OPENAS2_CONFIG__`
- `WebUI/docker/40-openas2-config.sh` — rewrites it from `OPENAS2_RESTAPI_URL`.
  Dropped into `/docker-entrypoint.d/`, which the official nginx image already
  sources, so no `ENTRYPOINT` override is needed.
- `LoginScreen.vue` — resolution order: runtime config → build-time
  `VUE_APP_RESTAPI_URL` → `http://127.0.0.1:8443/api`
- `docker-compose.yml` — build `args` become runtime `environment`

Default is `http://localhost:8443/api`, matching the compose REST API port.

**Backwards compatible.** The build arg still works and still wins over the
compiled default, so existing build pipelines are unaffected. The only behaviour
change is that `OPENAS2_RESTAPI_URL`, when set, takes precedence.

## Verification

Built the image and ran it both ways:

```
$ docker run -d -p 8080:80 openas2-webui
$ curl -s localhost:8080/config.js
window.__OPENAS2_CONFIG__ = { restApiUrl: "http://localhost:8443/api" };

$ docker run -d -p 8080:80 -e OPENAS2_RESTAPI_URL=https://as2.example.org/api openas2-webui
$ curl -s localhost:8080/config.js
window.__OPENAS2_CONFIG__ = { restApiUrl: "https://as2.example.org/api" };
```

Also confirmed `__OPENAS2_CONFIG__` is present in both the modern and legacy
compiled bundles, so the app actually reads it rather than the file merely being
served.

The change was additionally applied across the v4.1.0–v4.9.0 tags and built for
each; the anchors it touches are unchanged across that range.

## Note

The URL is interpolated into a JS string literal, so the entrypoint escapes
backslashes and double quotes. It is an operator-supplied value, not user input.
