### PR TITLE
Add API endpoint to download the stored MDN for a message

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -10,6 +10,17 @@ The zip file contains a PDF document (OpenAS2HowTo.pdf) providing information on
 ## NOTE: Testing covers Java 11 to 21.
 ##       Java 8 is NO LONGER SUPPORTED.
 
+Version UNRELEASED
+===========================
+
+This is a minor enhancement release.
+1. Add an API endpoint to download the stored MDN for a message: GET /api/messages/mdn/<msgId>, where <msgId> is the AS2
+   message ID of the message the MDN was returned for, URL encoded. The MDN is returned as a file attachment. Responds with
+   404 both when the message ID is unknown and when the MDN it recorded is no longer on disk, with different messages for
+   the two cases. Requires the DB tracking module and a storage module that records the MDN file path (see the
+   mdn_file_path column added in 4.9.0).
+
+
 Version 4.10.0 - 2026-08-17
 ===========================
 

--- a/Server/src/main/java/org/openas2/cmd/processor/restapi/ApiResource.java
+++ b/Server/src/main/java/org/openas2/cmd/processor/restapi/ApiResource.java
@@ -11,6 +11,9 @@ import org.openas2.cert.AliasedCertificateFactory;
 import org.openas2.cert.CertificateFactory;
 import org.openas2.cmd.CommandResult;
 import org.openas2.cmd.processor.RestCommandProcessor;
+import org.openas2.processor.ProcessorModule;
+import org.openas2.processor.msgtracking.DbTrackingModule;
+import org.openas2.processor.msgtracking.TrackingModule;
 
 import jakarta.annotation.security.RolesAllowed;
 import jakarta.ws.rs.Consumes;
@@ -37,6 +40,7 @@ import jakarta.ws.rs.core.Request;
 import jakarta.ws.rs.core.Response;
 import jakarta.ws.rs.core.UriInfo;
 import java.io.ByteArrayInputStream;
+import java.io.File;
 import java.security.cert.Certificate;
 import java.security.cert.X509Certificate;
 import java.util.ArrayList;
@@ -218,6 +222,98 @@ public class ApiResource {
     public Response headCommand(@PathParam("param") String command) {
         // Just an Empty response
         return Response.status(200).build();
+    }
+
+    /**
+     * Downloads the stored MDN for a message identified by its AS2 message ID.
+     * <p>
+     * The file that gets streamed is only ever the path recorded in the tracking database by the
+     * MDN storage module: the caller supplies a message ID, never a path, so this cannot be used to
+     * read arbitrary files. The content originates from a trading partner, so it is served as an
+     * attachment with no-sniff set rather than as anything a browser will render inline.
+     *
+     * @param msgId - the AS2 message ID of the message the MDN was returned for, URL encoded
+     * @return the MDN file as an attachment, or a JSON error result
+     */
+    @RolesAllowed({"ADMIN"})
+    @GET
+    @Path("/messages/mdn/{msgId}")
+    @Produces({MediaType.APPLICATION_OCTET_STREAM, MediaType.APPLICATION_JSON})
+    public Response downloadMdn(@PathParam("msgId") String msgId) throws Exception {
+        try {
+            if (msgId == null || msgId.trim().length() == 0) {
+                return errorResponse(400, "An AS2 message ID must be supplied.");
+            }
+            DbTrackingModule db = getDbTrackingModule();
+            if (db == null) {
+                return errorResponse(503, "No DB tracking module available so no MDN can be located.");
+            }
+
+            String trimmedId = msgId.trim();
+            String mdnFilePath = db.getMdnFilePathByMessageId(trimmedId);
+            if (mdnFilePath == null) {
+                return errorResponse(404, "No stored MDN found for message ID: " + trimmedId);
+            }
+
+            File mdnFile = new File(mdnFilePath);
+            if (!mdnFile.isFile() || !mdnFile.canRead()) {
+                // The tracking record outlives the file, so a missing file is a normal operational
+                // state (archived or cleaned up) rather than a server fault
+                LoggerFactory.getLogger(ApiResource.class.getName())
+                        .warn("MDN file recorded for message ID " + trimmedId + " is not readable: " + mdnFilePath);
+                return errorResponse(404, "The MDN recorded for message ID " + trimmedId
+                        + " is no longer available on disk.");
+            }
+
+            return Response.status(200)
+                    .entity(mdnFile)
+                    .type(MediaType.APPLICATION_OCTET_STREAM)
+                    .header("Content-Disposition", "attachment; filename=\"" + toSafeDownloadName(mdnFile) + "\"")
+                    .header("X-Content-Type-Options", "nosniff")
+                    .build();
+        } catch (Exception ex) {
+            LoggerFactory.getLogger(ApiResource.class.getName()).error(ex.getMessage(), ex);
+            throw ex;
+        }
+    }
+
+    /**
+     * @return the first configured DB tracking module, or null if message tracking is not using one
+     */
+    private DbTrackingModule getDbTrackingModule() throws Exception {
+        List<ProcessorModule> modules = getProcessor().getSession().getProcessor()
+                .getModulesSupportingAction(TrackingModule.DO_TRACK_MSG);
+        if (modules == null) {
+            return null;
+        }
+        for (ProcessorModule module : modules) {
+            if (module instanceof DbTrackingModule) {
+                return (DbTrackingModule) module;
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Reduces the stored file name to characters that are safe to place in a quoted
+     * Content-Disposition value. The name comes from the database so it is treated as untrusted:
+     * stripping everything else rules out header injection and quote breaking.
+     */
+    private String toSafeDownloadName(File mdnFile) {
+        String name = mdnFile.getName().replaceAll("[^A-Za-z0-9._-]", "_");
+        return name.length() == 0 ? "mdn" : name;
+    }
+
+    /**
+     * Builds an error response in the same JSON shape as the command backed endpoints so API clients
+     * get one consistent error format.
+     */
+    private Response errorResponse(int status, String message) throws Exception {
+        CommandResult result = new CommandResult(CommandResult.TYPE_ERROR, message);
+        return Response.status(status)
+                .entity(this.mapper.writerWithDefaultPrettyPrinter().writeValueAsString(result))
+                .type(MediaType.APPLICATION_JSON)
+                .build();
     }
 
     private CommandResult importCertificateByStream(String itemId, MultivaluedMap<String, String> formParams) throws Exception {

--- a/Server/src/main/java/org/openas2/processor/msgtracking/DbTrackingModule.java
+++ b/Server/src/main/java/org/openas2/processor/msgtracking/DbTrackingModule.java
@@ -284,6 +284,33 @@ public class DbTrackingModule extends BaseMsgTrackingModule {
         }
     }
 
+    /**
+     * Looks up the stored MDN file path for a message identified by its AS2 message ID. Rows with no
+     * recorded MDN path are ignored. The message ID is unique in the schema (msg_id_unique), so at
+     * most one row can match and no ordering is needed to make the result deterministic.
+     *
+     * @param msgId - the AS2 message ID of the message the MDN was returned for
+     * @return the stored MDN file path, or null if there is no match with a recorded MDN path
+     */
+    public String getMdnFilePathByMessageId(String msgId) {
+        if (msgId == null || msgId.length() == 0) {
+            return null;
+        }
+        String sql = "SELECT " + FIELDS.MDN_FILE_PATH + " FROM " + tableName
+                + " WHERE " + FIELDS.MSG_ID + " = ?"
+                + " AND " + FIELDS.MDN_FILE_PATH + " IS NOT NULL";
+        try (Connection conn = dbHandler.getConnection();
+                PreparedStatement s = conn.prepareStatement(sql)) {
+            s.setString(1, msgId);
+            try (ResultSet rs = s.executeQuery()) {
+                return rs.next() ? rs.getString(1) : null;
+            }
+        } catch (Exception e) {
+            logger.error("Failed to look up MDN file path for message ID: " + msgId, e);
+            return null;
+        }
+    }
+
     public ArrayList<HashMap<String, String>> getDataCharts(HashMap<String, String> map) {
         ArrayList<HashMap<String, String>> rows = new ArrayList<HashMap<String, String>>();
         try (Connection conn = dbHandler.getConnection()) {

--- a/Server/src/test/java/org/openas2/app/MdnDownloadApiTest.java
+++ b/Server/src/test/java/org/openas2/app/MdnDownloadApiTest.java
@@ -1,0 +1,234 @@
+package org.openas2.app;
+
+import org.apache.commons.lang3.exception.ExceptionUtils;
+import org.apache.http.Header;
+import org.apache.http.HttpEntity;
+import org.apache.http.auth.AuthScope;
+import org.apache.http.auth.UsernamePasswordCredentials;
+import org.apache.http.client.CredentialsProvider;
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.impl.client.BasicCredentialsProvider;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClientBuilder;
+import org.apache.http.util.EntityUtils;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.TestInstance.Lifecycle;
+import org.openas2.cmd.processor.restapi.AuthenticationRequestFilter;
+import org.openas2.util.Properties;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.UnsupportedEncodingException;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.PreparedStatement;
+import java.sql.Statement;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Verifies the API endpoint that downloads the stored MDN for a message.
+ * <p>
+ * The endpoint resolves an AS2 message ID against the tracking database and streams back the file
+ * that the MDN storage module recorded. As well as the download itself these tests cover the
+ * not-found paths that matter operationally: an unknown message ID, a message that has no recorded
+ * MDN, and a recorded MDN whose file has since been removed from disk.
+ */
+@TestInstance(Lifecycle.PER_CLASS)
+public class MdnDownloadApiTest extends BaseServerSetup {
+
+    private static final String REST_HOST = "http://127.0.0.1:8085";
+    private static final String BASE_URL = REST_HOST + "/api/";
+    private static final String AUTH_USER = "admin";
+    private static final String AUTH_PWD = "admin";
+
+    private static final String MSG_ID = "<MSG-WITH-MDN@openas2test>";
+    private static final String MDN_ID = "<MDN-FOR-MSG@openas2test>";
+    private static final String MSG_ID_FILE_GONE = "<MSG-MDN-FILE-GONE@openas2test>";
+    private static final String MSG_ID_NO_MDN = "<MSG-WITHOUT-MDN@openas2test>";
+
+    private static final String MDN_CONTENT = "Headers:\nMessage-ID: <MDN-FOR-MSG@openas2test>\n\nText:\nMessage received OK.";
+
+    private static OpenAS2Server serverInstance;
+    private static Connection dbConn;
+    private static File mdnFile;
+
+    @BeforeAll
+    public void setUp() throws Exception {
+        super.createFileSystemResources(this.getClass().getName());
+
+        try (FileOutputStream fos = new FileOutputStream(openAS2PropertiesFile)) {
+            fos.write("restapi.command.processor.enabled=true\n".getBytes());
+            fos.write(("restapi.command.processor.baseuri=" + REST_HOST + "\n").getBytes());
+            fos.write(("restapi.command.processor.userid=" + AUTH_USER + "\n").getBytes());
+            fos.write(("restapi.command.processor.password=" + AUTH_PWD + "\n").getBytes());
+        }
+        System.setProperty(Properties.OPENAS2_PROPERTIES_FILE_PROP, openAS2PropertiesFile.getAbsolutePath());
+        try {
+            serverInstance = new OpenAS2Server.Builder().run(configDir.getAbsolutePath() + "/config.xml");
+        } catch (Throwable e) {
+            // aid for debugging JUnit tests
+            System.err.println("ERROR occurred: " + ExceptionUtils.getStackTrace(e));
+            throw new Exception(e);
+        }
+
+        // The MDN the endpoint should hand back
+        mdnFile = new File(configDir, "stored-mdn-001.mdn");
+        Files.write(mdnFile.toPath(), MDN_CONTENT.getBytes(StandardCharsets.UTF_8));
+
+        // Seed the tracking table the endpoint reads. The server holds the embedded H2 file open, so
+        // this connects to the same database from within the same JVM rather than through the module.
+        dbConn = DriverManager.getConnection("jdbc:h2:" + configDir.getAbsolutePath() + "/DB/openas2", "sa", "OpenAS2");
+        // The tracking tables are not created automatically, so apply the shipped schema first
+        try (Statement s = dbConn.createStatement()) {
+            String ddl = new String(Files.readAllBytes(Paths.get("src", "config", "db_ddl.sql")), StandardCharsets.UTF_8);
+            for (String statement : ddl.split(";")) {
+                if (!statement.trim().isEmpty()) {
+                    s.execute(statement);
+                }
+            }
+        }
+        insertTrackingRow(MSG_ID, MDN_ID, mdnFile.getAbsolutePath());
+        insertTrackingRow(MSG_ID_FILE_GONE, "<MDN-FILE-GONE@openas2test>",
+                new File(configDir, "deleted-by-housekeeping.mdn").getAbsolutePath());
+        insertTrackingRow(MSG_ID_NO_MDN, null, null);
+    }
+
+    @AfterAll
+    public void tearDown() throws Exception {
+        if (dbConn != null) {
+            dbConn.close();
+        }
+        if (serverInstance != null) {
+            serverInstance.shutdown();
+        }
+        System.clearProperty(Properties.OPENAS2_PROPERTIES_FILE_PROP);
+    }
+
+    private void insertTrackingRow(String msgId, String mdnId, String mdnFilePath) throws Exception {
+        try (PreparedStatement s = dbConn.prepareStatement(
+                "INSERT INTO msg_metadata (MSG_ID, MDN_ID, SENDER_ID, RECEIVER_ID, MDN_FILE_PATH) VALUES (?, ?, ?, ?, ?)")) {
+            s.setString(1, msgId);
+            s.setString(2, mdnId);
+            s.setString(3, "MyCompany_OID");
+            s.setString(4, "PartnerA_OID");
+            s.setString(5, mdnFilePath);
+            s.executeUpdate();
+        }
+    }
+
+    @Test
+    public void downloadsTheMdnByMessageId() throws Exception {
+        ApiResponse response = downloadMdn(MSG_ID, true);
+
+        assertEquals(200, response.status);
+        assertEquals(MDN_CONTENT, response.body, "the endpoint must stream back the stored MDN unchanged");
+        assertEquals("attachment; filename=\"stored-mdn-001.mdn\"", response.header("Content-Disposition"));
+        assertEquals("nosniff", response.header("X-Content-Type-Options"));
+        assertEquals(1, response.headerCount("Content-Length"),
+                "a duplicated Content-Length is rejected by some clients");
+        assertEquals(String.valueOf(MDN_CONTENT.length()), response.header("Content-Length"));
+    }
+
+    @Test
+    public void unknownMessageIdIsNotFound() throws Exception {
+        ApiResponse response = downloadMdn("<NO-SUCH-MESSAGE@openas2test>", true);
+
+        assertEquals(404, response.status);
+        assertTrue(response.body.contains("No stored MDN found"),
+                "the error body should say the message ID matched nothing: " + response.body);
+    }
+
+    @Test
+    public void anMdnIdIsNotAcceptedAsAMessageId() throws Exception {
+        // The endpoint is keyed on the message ID only: the MDN's own ID must not resolve
+        assertEquals(404, downloadMdn(MDN_ID, true).status);
+    }
+
+    @Test
+    public void messageWithNoRecordedMdnIsNotFound() throws Exception {
+        ApiResponse response = downloadMdn(MSG_ID_NO_MDN, true);
+
+        assertEquals(404, response.status, "a tracked message that has no MDN recorded is not a download");
+    }
+
+    @Test
+    public void recordedMdnMissingFromDiskIsNotFound() throws Exception {
+        ApiResponse response = downloadMdn(MSG_ID_FILE_GONE, true);
+
+        assertEquals(404, response.status);
+        assertTrue(response.body.contains("no longer available on disk"),
+                "an archived or cleaned up MDN must be distinguishable from an unknown ID: " + response.body);
+    }
+
+    @Test
+    public void requiresAuthentication() throws Exception {
+        ApiResponse response = downloadMdn(MSG_ID, false);
+
+        assertTrue(response.body.contains(AuthenticationRequestFilter.ACCESS_DENIED_ERROR_MSG),
+                "MDN content must not be served without credentials: " + response.body);
+        assertNotEquals(MDN_CONTENT, response.body, "the MDN itself must not be in the body");
+    }
+
+    private ApiResponse downloadMdn(String msgId, boolean withAuth) throws IOException {
+        String url = BASE_URL + "messages/mdn/" + encodePathSegment(msgId);
+        HttpClientBuilder builder = HttpClientBuilder.create();
+        if (withAuth) {
+            CredentialsProvider provider = new BasicCredentialsProvider();
+            provider.setCredentials(AuthScope.ANY, new UsernamePasswordCredentials(AUTH_USER, AUTH_PWD));
+            builder = builder.setDefaultCredentialsProvider(provider);
+        }
+        try (CloseableHttpClient client = builder.build();
+             CloseableHttpResponse response = client.execute(new HttpGet(url))) {
+            HttpEntity entity = response.getEntity();
+            return new ApiResponse(response.getStatusLine().getStatusCode(),
+                    entity == null ? "" : EntityUtils.toString(entity),
+                    response);
+        }
+    }
+
+    /** Message IDs contain characters such as angle brackets and "@" that must be escaped in a path. */
+    private String encodePathSegment(String value) throws UnsupportedEncodingException {
+        return URLEncoder.encode(value, StandardCharsets.UTF_8.name());
+    }
+
+    private static final class ApiResponse {
+        private final int status;
+        private final String body;
+        private final CloseableHttpResponse response;
+
+        private ApiResponse(int status, String body, CloseableHttpResponse response) {
+            this.status = status;
+            this.body = body;
+            this.response = response;
+        }
+
+        private String header(String name) {
+            Header header = response.getFirstHeader(name);
+            return header == null ? null : header.getValue();
+        }
+
+        private int headerCount(String name) {
+            return response.getHeaders(name).length;
+        }
+    }
+
+    /** Guards against the fixture silently not being set up, which would make every test vacuous. */
+    @Test
+    public void fixtureIsUsable() {
+        assertNotNull(serverInstance, "the server must be running for these tests to mean anything");
+        assertTrue(mdnFile.isFile(), "the stored MDN fixture file must exist");
+    }
+}

--- a/Server/src/test/java/org/openas2/processor/msgtracking/DbTrackingModuleMdnPathTest.java
+++ b/Server/src/test/java/org/openas2/processor/msgtracking/DbTrackingModuleMdnPathTest.java
@@ -21,9 +21,10 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
 /**
- * Verifies that the MDN file path is written to the tracking record and can be looked up by the
- * message's payload filename via DbTrackingModule.getMdnFilePath (which backs the messages/mdnpath
- * command and its REST endpoint).
+ * Verifies that the MDN file path is written to the tracking record and can be looked up again by
+ * the message's payload filename (DbTrackingModule.getMdnFilePath, which backs the messages/mdnpath
+ * command) or by the AS2 message ID (getMdnFilePathByMessageId, which backs the MDN download
+ * endpoint).
  */
 @TestInstance(Lifecycle.PER_CLASS)
 public class DbTrackingModuleMdnPathTest extends BaseServerSetup {
@@ -51,8 +52,15 @@ public class DbTrackingModuleMdnPathTest extends BaseServerSetup {
     }
 
     private void persist(String msgId, String fileName, String sentFileName, String mdnPath) {
+        persist(msgId, null, fileName, sentFileName, mdnPath);
+    }
+
+    private void persist(String msgId, String mdnId, String fileName, String sentFileName, String mdnPath) {
         Map<String, String> map = new HashMap<String, String>();
         map.put(DbTrackingModule.FIELDS.MSG_ID, msgId);
+        if (mdnId != null) {
+            map.put(DbTrackingModule.FIELDS.MDN_ID, mdnId);
+        }
         map.put(DbTrackingModule.FIELDS.SENDER_ID, "SENDER");
         map.put(DbTrackingModule.FIELDS.RECEIVER_ID, "RECEIVER");
         if (fileName != null) {
@@ -90,5 +98,34 @@ public class DbTrackingModuleMdnPathTest extends BaseServerSetup {
         persist("<m3>", "no-mdn-yet.edi", null, null);
         assertNull(db.getMdnFilePath("no-mdn-yet.edi"),
                 "a tracked message with no recorded MDN path should not be returned");
+    }
+
+    @Test
+    public void mdnPathIsLookedUpByMessageId() {
+        persist("<msg-id-lookup@openas2>", "<mdn-id-lookup@openas2>", "byid.edi", null, "/data/mdn/byid.mdn");
+
+        assertEquals("/data/mdn/byid.mdn", db.getMdnFilePathByMessageId("<msg-id-lookup@openas2>"));
+    }
+
+    @Test
+    public void theMdnIdIsNotMatchedByTheMessageIdLookup() {
+        persist("<msg-not-mdn@openas2>", "<mdn-not-msg@openas2>", "notmdn.edi", null, "/data/mdn/notmdn.mdn");
+
+        assertNull(db.getMdnFilePathByMessageId("<mdn-not-msg@openas2>"),
+                "the lookup is keyed on the message ID only, so an MDN ID must not resolve");
+    }
+
+    @Test
+    public void messageIdLookupIgnoresRecordsWithNoMdnPath() {
+        persist("<msg-id-no-mdn@openas2>", "<mdn-id-no-mdn@openas2>", "idnomdn.edi", null, null);
+
+        assertNull(db.getMdnFilePathByMessageId("<msg-id-no-mdn@openas2>"));
+    }
+
+    @Test
+    public void blankOrUnknownMessageIdReturnsNull() {
+        assertNull(db.getMdnFilePathByMessageId("<not-a-known-id@openas2>"));
+        assertNull(db.getMdnFilePathByMessageId(""));
+        assertNull(db.getMdnFilePathByMessageId(null));
     }
 }

--- a/changes.txt
+++ b/changes.txt
@@ -1,5 +1,16 @@
 **IMPORTANT NOTE**: Please review upgrade notes in the RELEASE-NOTES.md if you are upgrading
 
+Version UNRELEASED
+===========================
+
+This is a minor enhancement release.
+1. Add an API endpoint to download the stored MDN for a message: GET /api/messages/mdn/<msgId>, where <msgId> is the AS2
+   message ID of the message the MDN was returned for, URL encoded. The MDN is returned as a file attachment. Responds with
+   404 both when the message ID is unknown and when the MDN it recorded is no longer on disk, with different messages for
+   the two cases. Requires the DB tracking module and a storage module that records the MDN file path (see the
+   mdn_file_path column added in 4.9.0).
+
+
 Version 4.10.0 - 2026-08-17
 ===========================
 


### PR DESCRIPTION
The MDN file path has been recorded in the tracking database since 4.9.0 but there was no way to retrieve the MDN itself: messages/mdnpath only returns the path, which is of no use to a caller that is not on the server's file system.

Adds GET /api/messages/mdn/<msgId>, which resolves the AS2 message ID against the tracking database and streams the recorded file back as an attachment. The message ID is the unique key of the tracking table, so at most one row can match.

The caller only ever supplies a message ID, never a path, so the endpoint cannot be used to read arbitrary files: the path comes from the database and is written there by the MDN storage module. The content originates from a trading partner, so it is served as an attachment with nosniff set rather than as anything a browser will render inline, and the file name is reduced to safe characters before it goes into the Content-Disposition header. The endpoint requires the ADMIN role like every other API endpoint.

A tracking record outlives the file it points at, so an MDN that has been archived or cleaned up returns 404 with a message that distinguishes it from a message ID that matched nothing at all.