### PR TITLE
Resend tracking fixes

### DIFF
--- a/Server/src/main/java/org/openas2/message/BaseMessage.java
+++ b/Server/src/main/java/org/openas2/message/BaseMessage.java
@@ -367,6 +367,12 @@ public abstract class BaseMessage implements Message {
         // read in attributes
         attributes = (Map<String, String>) in.readObject();
 
+        // read in payload filename
+        payloadFilename = (String) in.readObject();
+
+        // read in resend flag
+        isResending = in.readBoolean();
+
         // read in data history
         history = (DataHistory) in.readObject();
 
@@ -398,6 +404,12 @@ public abstract class BaseMessage implements Message {
 
         // write attributes
         out.writeObject(attributes);
+
+        // write payload filename
+        out.writeObject(payloadFilename);
+
+        // write resend flag
+        out.writeBoolean(isResending);
 
         // write data history
         out.writeObject(history);

--- a/Server/src/main/java/org/openas2/util/AS2Util.java
+++ b/Server/src/main/java/org/openas2/util/AS2Util.java
@@ -366,8 +366,6 @@ public class AS2Util {
                 // Signal sending retry has been abandoned
                 return false;
             }
-            // Going to try again so increment the try count
-            retries++;
         }
         // Keep a popinter to the passed in msg object in case it is overwritten in this method so that setting
         // the resend flag to avoid file cleanup is not lost when this method exits and the original initiating

--- a/Server/src/test/java/org/openas2/processor/resender/DirectoryResenderModuleTest.java
+++ b/Server/src/test/java/org/openas2/processor/resender/DirectoryResenderModuleTest.java
@@ -123,6 +123,24 @@ public class DirectoryResenderModuleTest {
     }
 
     @Test
+    public void processFilePreservesPayloadFilenameAndResendFlagAcrossSerialization() throws Exception {
+        Message original = message("<resend-filename>");
+        original.setPayloadFilename("invoice123.edi");
+
+        module.handle(ResenderModule.DO_RESEND, original, resendOptions(SenderModule.DO_SEND, 0));
+        File queued = resendFiles()[0];
+
+        module.processFile(queued);
+
+        ArgumentCaptor<Message> msgCaptor = ArgumentCaptor.forClass(Message.class);
+        verify(processor).handle(eq(SenderModule.DO_SEND), msgCaptor.capture(), any());
+        Message resent = msgCaptor.getValue();
+        assertEquals("invoice123.edi", resent.getPayloadFilename(),
+                "payload filename should survive the serialize/deserialize round trip through the resend queue");
+        assertTrue(resent.isResend(), "resend flag should survive the serialize/deserialize round trip");
+    }
+
+    @Test
     public void processFileArchivesToErrorDirWhenResendFails() throws Exception {
         doThrow(new OpenAS2Exception("send failed")).when(processor).handle(any(), any(), any());
 


### PR DESCRIPTION
Fixes to include file_name in dbtracking on resends, correctly identifying is_resend in dbtracking, and only increment resend_count once on message resend.