### PR TITLE
Add tool to migrate a partnerships XML file into the database

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -9,6 +9,18 @@ The release download file is: OpenAS2Server-4.11.0.zip
 The zip file contains a PDF document (OpenAS2HowTo.pdf) providing information on installing and using the application.
 ## NOTE: Testing covers Java 17 to 21.
 
+Version UNRELEASED
+===========================
+
+This is a minor enhancement release.
+1. Add a migration tool that loads a partnerships XML file into the partner and partnership database tables read by
+   DbPartnershipFactory, so an existing XML configuration can be moved to the database store without being retyped:
+   bin/upgrade/migrate_partnerships_to_db.sh <partnerships.xml> <jdbc_url> <db_user> <db_password>. Sender and receiver
+   overrides and pollerConfig entries are carried across as their respective attribute categories, and values are stored
+   unresolved so placeholders such as $properties.storageBaseDir$ keep working. Pass --dry-run to validate the file and
+   see what would be written without touching the database, or --replace to overwrite partnerships already stored there.
+   The whole migration runs in one transaction, so a file that cannot be represented in the schema leaves it untouched.
+
 Version 4.11.0 - 2026-09-02
 ===========================
 

--- a/Server/src/bin/upgrade/migrate_partnerships_to_db.sh
+++ b/Server/src/bin/upgrade/migrate_partnerships_to_db.sh
@@ -1,0 +1,52 @@
+#!/bin/bash
+# purpose: migrates a partnerships XML file into the partner and partnership database tables
+#          read by org.openas2.partner.DbPartnershipFactory
+set -e
+
+x=`basename $0`
+scriptDir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+if test $# -lt 1; then
+  echo "Migrates a partnerships XML file into the OpenAS2 partnership database tables so the"
+  echo "partnerships component can be switched from XMLPartnershipFactory to DbPartnershipFactory."
+  echo ""
+  echo "usage: ${x} <partnerships.xml> <jdbc_url> <db_user> <db_password> [options]"
+  echo "       ${x} <partnerships.xml> --dry-run"
+  echo ""
+  echo "options:"
+  echo "  --dry-run              Parse and validate the file and print what would be written. Changes nothing."
+  echo "  --replace              Delete the partner and partnership rows already in the database first."
+  echo "                         Without this the migration aborts if either table has any rows."
+  echo "  --jdbc-driver=<class>  Load this JDBC driver class before connecting. Only needed for a"
+  echo "                         driver that does not register itself automatically."
+  echo ""
+  echo "The tables must already exist. Create them with the partner and partnership section of"
+  echo "config/db_ddl.sql before running this. Copy out just that section: running the whole file"
+  echo "drops the msg_metadata message tracking table."
+  echo ""
+  echo "A driver for your database must be on the classpath. The bundled H2 driver is already in"
+  echo "lib. For anything else, put the driver jar in the lib directory alongside it."
+  echo ""
+  echo "examples:"
+  echo "  ${x} ../config/partnerships.xml --dry-run"
+  echo "  ${x} ../config/partnerships.xml \"jdbc:h2:../data/openas2\" sa OpenAS2"
+  exit 1
+fi
+
+# Locate a JVM the same way the server start script does
+if [ -z $JAVA_HOME ]; then
+  if [ -x /usr/libexec/java_home ]; then
+    JAVA_HOME=$(/usr/libexec/java_home)
+  elif [ -n "$(command -v java)" ]; then
+    JAVA_HOME=$(dirname $(dirname $(readlink -f $(command -v java))))
+  fi
+fi
+if [ -z $JAVA_HOME ]; then
+  echo "ERROR: Cannot find JAVA_HOME. Set it and re-run."
+  exit 1
+fi
+
+# This script lives in bin/upgrade so the application jars are two levels up
+CLASSPATH=$(echo "${scriptDir}/../../lib/"*".jar" | tr ' ' ':')
+
+exec "${JAVA_HOME}/bin/java" -cp ".:${CLASSPATH}" org.openas2.upgrades.MigratePartnershipsToDb "$@"

--- a/Server/src/main/java/org/openas2/upgrades/MigratePartnershipsToDb.java
+++ b/Server/src/main/java/org/openas2/upgrades/MigratePartnershipsToDb.java
@@ -1,0 +1,537 @@
+package org.openas2.upgrades;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.InputStream;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+
+import org.openas2.OpenAS2Exception;
+import org.openas2.partner.DbPartnershipFactory;
+import org.openas2.partner.Partnership;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.w3c.dom.NamedNodeMap;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
+
+/**
+ * Migrates a partnerships XML file into the database tables read by
+ * {@link org.openas2.partner.DbPartnershipFactory}.
+ * <p>
+ * The mapping mirrors what each factory does when it loads, so a migrated database produces the same
+ * partnerships the XML file produced:
+ * <ul>
+ * <li>a "partner" element becomes a partner row plus a partner_attribute row for every attribute
+ * other than the name, which is held in the partner row itself</li>
+ * <li>a "partnership" element becomes a partnership row whose sender and receiver columns point at
+ * the partner rows named by its sender and receiver elements</li>
+ * <li>any attribute other than the name on those sender and receiver elements is a per-partnership
+ * override and becomes a partnership_attribute row in the "sender" or "receiver" category</li>
+ * <li>each "attribute" child becomes a partnership_attribute row in the "attribute" category</li>
+ * <li>each attribute of the "pollerConfig" child becomes a partnership_attribute row in the
+ * "pollerConfig" category</li>
+ * </ul>
+ * Values are stored exactly as they appear in the file. Placeholders such as
+ * $properties.storageBaseDir$ are deliberately left unresolved because both factories resolve them
+ * when the partnerships are loaded, so resolving them here would freeze the value of a setting that
+ * is meant to stay dynamic.
+ * <p>
+ * The whole migration runs in one transaction: if anything fails to validate, nothing is written.
+ */
+public class MigratePartnershipsToDb {
+
+    private static final int MAX_ATTRIBUTE_VALUE_LENGTH = 4000;
+
+    /** Counts of what was written, for reporting. */
+    public static class Result {
+        private int partners;
+        private int partnerAttributes;
+        private int partnerships;
+        private int partnershipAttributes;
+        private int senderOverrides;
+        private int receiverOverrides;
+        private int pollerConfigAttributes;
+
+        public int getPartners() {
+            return partners;
+        }
+
+        public int getPartnerAttributes() {
+            return partnerAttributes;
+        }
+
+        public int getPartnerships() {
+            return partnerships;
+        }
+
+        public int getPartnershipAttributes() {
+            return partnershipAttributes;
+        }
+
+        public int getSenderOverrides() {
+            return senderOverrides;
+        }
+
+        public int getReceiverOverrides() {
+            return receiverOverrides;
+        }
+
+        public int getPollerConfigAttributes() {
+            return pollerConfigAttributes;
+        }
+
+        public String describe() {
+            return partners + " partner(s) with " + partnerAttributes + " attribute(s), "
+                    + partnerships + " partnership(s) with " + partnershipAttributes + " attribute(s), "
+                    + senderOverrides + " sender override(s), " + receiverOverrides + " receiver override(s), "
+                    + pollerConfigAttributes + " poller config attribute(s)";
+        }
+    }
+
+    /** One partner element read from the file. */
+    private static class ParsedPartner {
+        private String name;
+        private Map<String, String> attributes = new LinkedHashMap<String, String>();
+    }
+
+    /** One partnership element read from the file. */
+    private static class ParsedPartnership {
+        private String name;
+        private String senderPartnerName;
+        private String receiverPartnerName;
+        private Map<String, String> senderOverrides = new LinkedHashMap<String, String>();
+        private Map<String, String> receiverOverrides = new LinkedHashMap<String, String>();
+        private Map<String, String> attributes = new LinkedHashMap<String, String>();
+        private Map<String, String> pollerConfig = new LinkedHashMap<String, String>();
+        private boolean hasPollerConfig;
+    }
+
+    private final List<ParsedPartner> partners = new ArrayList<ParsedPartner>();
+    private final List<ParsedPartnership> partnerships = new ArrayList<ParsedPartnership>();
+
+    /**
+     * Reads and validates the partnerships file without touching the database.
+     *
+     * @param partnershipsFile - the partnerships XML file to migrate
+     * @throws OpenAS2Exception if the file cannot be parsed or describes something the schema
+     *                          cannot represent
+     */
+    public void parse(File partnershipsFile) throws OpenAS2Exception {
+        Document doc;
+        try (InputStream in = new FileInputStream(partnershipsFile)) {
+            DocumentBuilder parser = DocumentBuilderFactory.newInstance().newDocumentBuilder();
+            doc = parser.parse(in);
+        } catch (Exception e) {
+            throw new OpenAS2Exception("Failed to parse the partnerships file: " + partnershipsFile.getAbsolutePath(), e);
+        }
+        NodeList nodes = doc.getDocumentElement().getChildNodes();
+        for (int i = 0; i < nodes.getLength(); i++) {
+            Node node = nodes.item(i);
+            if ("partner".equals(node.getNodeName())) {
+                partners.add(parsePartner(node));
+            } else if ("partnership".equals(node.getNodeName())) {
+                partnerships.add(parsePartnership(node));
+            }
+        }
+        validate();
+    }
+
+    private ParsedPartner parsePartner(Node node) throws OpenAS2Exception {
+        ParsedPartner partner = new ParsedPartner();
+        NamedNodeMap attribs = node.getAttributes();
+        for (int i = 0; i < attribs.getLength(); i++) {
+            Node attrib = attribs.item(i);
+            if (Partnership.PID_NAME.equals(attrib.getNodeName())) {
+                // Held in the partner row itself, not as an attribute row
+                partner.name = attrib.getNodeValue();
+            } else {
+                partner.attributes.put(attrib.getNodeName(), attrib.getNodeValue());
+            }
+        }
+        if (partner.name == null || partner.name.length() == 0) {
+            throw new OpenAS2Exception("A partner element has no \"name\" attribute so it cannot be migrated.");
+        }
+        return partner;
+    }
+
+    private ParsedPartnership parsePartnership(Node node) throws OpenAS2Exception {
+        ParsedPartnership partnership = new ParsedPartnership();
+        Node nameNode = node.getAttributes().getNamedItem(Partnership.PID_NAME);
+        if (nameNode == null || nameNode.getNodeValue().length() == 0) {
+            throw new OpenAS2Exception("A partnership element has no \"name\" attribute so it cannot be migrated.");
+        }
+        partnership.name = nameNode.getNodeValue();
+
+        NodeList children = node.getChildNodes();
+        for (int i = 0; i < children.getLength(); i++) {
+            Node child = children.item(i);
+            String childName = child.getNodeName();
+            if (Partnership.PTYPE_SENDER.equals(childName)) {
+                partnership.senderPartnerName = readPartnerRef(partnership, child, partnership.senderOverrides);
+            } else if (Partnership.PTYPE_RECEIVER.equals(childName)) {
+                partnership.receiverPartnerName = readPartnerRef(partnership, child, partnership.receiverOverrides);
+            } else if ("attribute".equals(childName)) {
+                Node attrName = child.getAttributes().getNamedItem("name");
+                Node attrValue = child.getAttributes().getNamedItem("value");
+                if (attrName == null) {
+                    throw new OpenAS2Exception("Partnership \"" + partnership.name + "\" has an attribute element with no \"name\".");
+                }
+                partnership.attributes.put(attrName.getNodeValue(), attrValue == null ? "" : attrValue.getNodeValue());
+            } else if (Partnership.PCFG_POLLER.equals(childName)) {
+                partnership.hasPollerConfig = true;
+                NamedNodeMap pollerAttribs = child.getAttributes();
+                for (int j = 0; j < pollerAttribs.getLength(); j++) {
+                    Node attrib = pollerAttribs.item(j);
+                    partnership.pollerConfig.put(attrib.getNodeName(), attrib.getNodeValue());
+                }
+            }
+        }
+        if (partnership.senderPartnerName == null) {
+            throw new OpenAS2Exception("Partnership \"" + partnership.name + "\" has no " + Partnership.PTYPE_SENDER
+                    + " element naming a partner. The database schema requires every partnership to reference a partner row"
+                    + " for its sender and receiver, so give the element a \"name\" that matches a partner and re-run.");
+        }
+        if (partnership.receiverPartnerName == null) {
+            throw new OpenAS2Exception("Partnership \"" + partnership.name + "\" has no " + Partnership.PTYPE_RECEIVER
+                    + " element naming a partner. The database schema requires every partnership to reference a partner row"
+                    + " for its sender and receiver, so give the element a \"name\" that matches a partner and re-run.");
+        }
+        return partnership;
+    }
+
+    /**
+     * Reads a sender or receiver element: the "name" identifies the partner row to point at and every
+     * other attribute is an override stored against the partnership.
+     */
+    private String readPartnerRef(ParsedPartnership partnership, Node node, Map<String, String> overrides) {
+        String partnerName = null;
+        NamedNodeMap attribs = node.getAttributes();
+        for (int i = 0; i < attribs.getLength(); i++) {
+            Node attrib = attribs.item(i);
+            if (Partnership.PID_NAME.equals(attrib.getNodeName())) {
+                partnerName = attrib.getNodeValue();
+            } else {
+                overrides.put(attrib.getNodeName(), attrib.getNodeValue());
+            }
+        }
+        return partnerName;
+    }
+
+    private void validate() throws OpenAS2Exception {
+        List<String> partnerNames = new ArrayList<String>();
+        for (ParsedPartner partner : partners) {
+            if (partnerNames.contains(partner.name)) {
+                throw new OpenAS2Exception("Partner is defined more than once: " + partner.name);
+            }
+            partnerNames.add(partner.name);
+            checkValueLengths("partner \"" + partner.name + "\"", partner.attributes);
+        }
+        List<String> partnershipNames = new ArrayList<String>();
+        for (ParsedPartnership partnership : partnerships) {
+            if (partnershipNames.contains(partnership.name)) {
+                throw new OpenAS2Exception("Partnership is defined more than once: " + partnership.name);
+            }
+            partnershipNames.add(partnership.name);
+            if (!partnerNames.contains(partnership.senderPartnerName)) {
+                throw new OpenAS2Exception("Partnership \"" + partnership.name + "\" has an undefined "
+                        + Partnership.PTYPE_SENDER + ": " + partnership.senderPartnerName);
+            }
+            if (!partnerNames.contains(partnership.receiverPartnerName)) {
+                throw new OpenAS2Exception("Partnership \"" + partnership.name + "\" has an undefined "
+                        + Partnership.PTYPE_RECEIVER + ": " + partnership.receiverPartnerName);
+            }
+            String where = "partnership \"" + partnership.name + "\"";
+            checkValueLengths(where, partnership.attributes);
+            checkValueLengths(where + " " + Partnership.PTYPE_SENDER, partnership.senderOverrides);
+            checkValueLengths(where + " " + Partnership.PTYPE_RECEIVER, partnership.receiverOverrides);
+            checkValueLengths(where + " " + Partnership.PCFG_POLLER, partnership.pollerConfig);
+        }
+    }
+
+    private void checkValueLengths(String where, Map<String, String> attributes) throws OpenAS2Exception {
+        for (Map.Entry<String, String> entry : attributes.entrySet()) {
+            if (entry.getValue() != null && entry.getValue().length() > MAX_ATTRIBUTE_VALUE_LENGTH) {
+                throw new OpenAS2Exception("The value of \"" + entry.getKey() + "\" on " + where + " is "
+                        + entry.getValue().length() + " characters, which exceeds the "
+                        + MAX_ATTRIBUTE_VALUE_LENGTH + " character attribute value column. Shorten it or widen the column.");
+            }
+        }
+    }
+
+    /**
+     * Writes the parsed partnerships to the database in a single transaction.
+     *
+     * @param conn - an open connection to the database holding the partner and partnership tables
+     * @param replaceExisting - true to delete the partner and partnership rows already present first.
+     *                          When false the migration aborts if any are present, so an accidental
+     *                          second run cannot merge two configurations together.
+     * @return counts of what was written
+     * @throws OpenAS2Exception if the tables are missing, already populated, or the write fails
+     */
+    public Result write(Connection conn, boolean replaceExisting) throws OpenAS2Exception {
+        Result result = new Result();
+        boolean originalAutoCommit;
+        try {
+            originalAutoCommit = conn.getAutoCommit();
+        } catch (SQLException e) {
+            throw new OpenAS2Exception("Failed to read the connection state.", e);
+        }
+        try {
+            conn.setAutoCommit(false);
+            try {
+                if (replaceExisting) {
+                    // Child tables first: the partnership and partner rows are referenced by foreign keys
+                    execute(conn, "DELETE FROM partnership_attribute");
+                    execute(conn, "DELETE FROM partnership");
+                    execute(conn, "DELETE FROM partner_attribute");
+                    execute(conn, "DELETE FROM partner");
+                } else {
+                    requireEmpty(conn, "partner");
+                    requireEmpty(conn, "partnership");
+                }
+                Map<String, Long> partnerIds = insertPartners(conn, result);
+                insertPartnerships(conn, partnerIds, result);
+                conn.commit();
+            } catch (Exception e) {
+                conn.rollback();
+                throw e;
+            }
+        } catch (OpenAS2Exception e) {
+            throw e;
+        } catch (Exception e) {
+            throw new OpenAS2Exception("Failed to write the partnerships to the database.", e);
+        } finally {
+            try {
+                conn.setAutoCommit(originalAutoCommit);
+            } catch (SQLException e) {
+                // Nothing useful to do: the migration has already committed or rolled back
+            }
+        }
+        return result;
+    }
+
+    private Map<String, Long> insertPartners(Connection conn, Result result) throws Exception {
+        Map<String, Long> partnerIds = new LinkedHashMap<String, Long>();
+        for (ParsedPartner partner : partners) {
+            try (PreparedStatement s = conn.prepareStatement("INSERT INTO partner (NAME) VALUES (?)")) {
+                s.setString(1, partner.name);
+                s.executeUpdate();
+            }
+            Long id = findId(conn, "SELECT ID FROM partner WHERE NAME = ?", partner.name);
+            if (id == null) {
+                throw new OpenAS2Exception("Failed to read back the inserted partner: " + partner.name);
+            }
+            partnerIds.put(partner.name, id);
+            result.partners++;
+            try (PreparedStatement s = conn.prepareStatement(
+                    "INSERT INTO partner_attribute (PARTNER_ID, ATTRIBUTE_NAME, ATTRIBUTE_VALUE) VALUES (?, ?, ?)")) {
+                for (Map.Entry<String, String> attribute : partner.attributes.entrySet()) {
+                    s.setLong(1, id);
+                    s.setString(2, attribute.getKey());
+                    s.setString(3, attribute.getValue());
+                    s.executeUpdate();
+                    result.partnerAttributes++;
+                }
+            }
+        }
+        return partnerIds;
+    }
+
+    private void insertPartnerships(Connection conn, Map<String, Long> partnerIds, Result result) throws Exception {
+        for (ParsedPartnership partnership : partnerships) {
+            try (PreparedStatement s = conn.prepareStatement(
+                    "INSERT INTO partnership (NAME, SENDER_PARTNER_ID, RECEIVER_PARTNER_ID) VALUES (?, ?, ?)")) {
+                s.setString(1, partnership.name);
+                s.setLong(2, partnerIds.get(partnership.senderPartnerName));
+                s.setLong(3, partnerIds.get(partnership.receiverPartnerName));
+                s.executeUpdate();
+            }
+            Long id = findId(conn, "SELECT ID FROM partnership WHERE NAME = ?", partnership.name);
+            if (id == null) {
+                throw new OpenAS2Exception("Failed to read back the inserted partnership: " + partnership.name);
+            }
+            result.partnerships++;
+            result.partnershipAttributes += insertAttributes(conn, id, DbPartnershipFactory.CATEGORY_ATTRIBUTE, partnership.attributes);
+            result.senderOverrides += insertAttributes(conn, id, DbPartnershipFactory.CATEGORY_SENDER, partnership.senderOverrides);
+            result.receiverOverrides += insertAttributes(conn, id, DbPartnershipFactory.CATEGORY_RECEIVER, partnership.receiverOverrides);
+            result.pollerConfigAttributes += insertAttributes(conn, id, DbPartnershipFactory.CATEGORY_POLLER_CONFIG, partnership.pollerConfig);
+        }
+    }
+
+    private int insertAttributes(Connection conn, long partnershipId, String category, Map<String, String> attributes) throws Exception {
+        if (attributes.isEmpty()) {
+            return 0;
+        }
+        int count = 0;
+        try (PreparedStatement s = conn.prepareStatement(
+                "INSERT INTO partnership_attribute (PARTNERSHIP_ID, CATEGORY, ATTRIBUTE_NAME, ATTRIBUTE_VALUE) VALUES (?, ?, ?, ?)")) {
+            for (Map.Entry<String, String> attribute : attributes.entrySet()) {
+                s.setLong(1, partnershipId);
+                s.setString(2, category);
+                s.setString(3, attribute.getKey());
+                s.setString(4, attribute.getValue());
+                s.executeUpdate();
+                count++;
+            }
+        }
+        return count;
+    }
+
+    private void requireEmpty(Connection conn, String table) throws Exception {
+        try (PreparedStatement s = conn.prepareStatement("SELECT COUNT(*) FROM " + table);
+             ResultSet rs = s.executeQuery()) {
+            rs.next();
+            long count = rs.getLong(1);
+            if (count > 0) {
+                throw new OpenAS2Exception("The \"" + table + "\" table already contains " + count
+                        + " row(s). Migrating now would merge two configurations together. Empty the partner and"
+                        + " partnership tables first, or re-run with --replace to have this tool delete them.");
+            }
+        }
+    }
+
+    private void execute(Connection conn, String sql) throws Exception {
+        try (PreparedStatement s = conn.prepareStatement(sql)) {
+            s.executeUpdate();
+        }
+    }
+
+    private Long findId(Connection conn, String sql, String key) throws Exception {
+        try (PreparedStatement s = conn.prepareStatement(sql)) {
+            s.setString(1, key);
+            try (ResultSet rs = s.executeQuery()) {
+                return rs.next() ? rs.getLong(1) : null;
+            }
+        }
+    }
+
+    /**
+     * Describes what would be written, for a dry run.
+     */
+    public String describeParsed() {
+        StringBuilder buf = new StringBuilder();
+        buf.append("Partners (").append(partners.size()).append("):").append(System.lineSeparator());
+        for (ParsedPartner partner : partners) {
+            buf.append("  ").append(partner.name).append(" -> ").append(partner.attributes.size())
+                    .append(" attribute(s): ").append(partner.attributes.keySet()).append(System.lineSeparator());
+        }
+        buf.append("Partnerships (").append(partnerships.size()).append("):").append(System.lineSeparator());
+        for (ParsedPartnership partnership : partnerships) {
+            buf.append("  ").append(partnership.name)
+                    .append(" [").append(partnership.senderPartnerName).append(" -> ").append(partnership.receiverPartnerName).append("]")
+                    .append(" attributes=").append(partnership.attributes.size())
+                    .append(" senderOverrides=").append(partnership.senderOverrides.size())
+                    .append(" receiverOverrides=").append(partnership.receiverOverrides.size())
+                    .append(" pollerConfig=").append(partnership.hasPollerConfig ? String.valueOf(partnership.pollerConfig.size()) : "none")
+                    .append(System.lineSeparator());
+        }
+        return buf.toString();
+    }
+
+    private static void usage() {
+        System.out.println("Migrates a partnerships XML file into the partner and partnership database tables");
+        System.out.println("read by org.openas2.partner.DbPartnershipFactory.");
+        System.out.println();
+        System.out.println("Usage:");
+        System.out.println("  MigratePartnershipsToDb <partnerships.xml> <jdbc_url> <db_user> <db_password> [options]");
+        System.out.println();
+        System.out.println("Options:");
+        System.out.println("  --dry-run              Parse and validate the file and print what would be written. Changes nothing.");
+        System.out.println("  --replace              Delete the partner and partnership rows already in the database first.");
+        System.out.println("                         Without this the migration aborts if either table has any rows.");
+        System.out.println("  --jdbc-driver=<class>  Load this JDBC driver class before connecting. Only needed for a driver");
+        System.out.println("                         that does not register itself automatically.");
+        System.out.println();
+        System.out.println("The tables must already exist. Create them with the partner and partnership section of");
+        System.out.println("config/db_ddl.sql (or resources/db/openas2-schema.xml) before running this. Copy out just");
+        System.out.println("that section: running the whole file drops the msg_metadata message tracking table.");
+        System.out.println();
+        System.out.println("Example:");
+        System.out.println("  MigratePartnershipsToDb /opt/OpenAS2/config/partnerships.xml \\");
+        System.out.println("      \"jdbc:h2:/opt/OpenAS2/data/openas2\" sa OpenAS2 --dry-run");
+    }
+
+    public static void main(String[] args) {
+        if (args == null || args.length < 1 || "--help".equals(args[0]) || "-h".equals(args[0])) {
+            usage();
+            System.exit(args == null || args.length < 1 ? 1 : 0);
+            return;
+        }
+        boolean dryRun = false;
+        boolean replace = false;
+        String jdbcDriver = null;
+        List<String> positional = new ArrayList<String>();
+        for (String arg : args) {
+            if ("--dry-run".equals(arg)) {
+                dryRun = true;
+            } else if ("--replace".equals(arg)) {
+                replace = true;
+            } else if (arg.startsWith("--jdbc-driver=")) {
+                jdbcDriver = arg.substring("--jdbc-driver=".length());
+            } else if (arg.startsWith("--")) {
+                System.err.println("Unknown option: " + arg);
+                usage();
+                System.exit(1);
+                return;
+            } else {
+                positional.add(arg);
+            }
+        }
+        int required = dryRun ? 1 : 4;
+        if (positional.size() < required) {
+            System.err.println(dryRun
+                    ? "A dry run requires the partnerships file."
+                    : "Requires the partnerships file, JDBC URL, database user and password.");
+            usage();
+            System.exit(1);
+            return;
+        }
+        File partnershipsFile = new File(positional.get(0));
+        if (!partnershipsFile.isFile()) {
+            System.err.println("No partnerships file found at: " + partnershipsFile.getAbsolutePath());
+            System.exit(1);
+            return;
+        }
+
+        MigratePartnershipsToDb migrator = new MigratePartnershipsToDb();
+        try {
+            migrator.parse(partnershipsFile);
+            System.out.println("Parsed " + partnershipsFile.getAbsolutePath() + ":");
+            System.out.println(migrator.describeParsed());
+            if (dryRun) {
+                System.out.println("Dry run: nothing was written to any database.");
+                return;
+            }
+            if (jdbcDriver != null) {
+                Class.forName(jdbcDriver);
+            }
+            try (Connection conn = DriverManager.getConnection(positional.get(1), positional.get(2), positional.get(3))) {
+                Result result = migrator.write(conn, replace);
+                System.out.println("Migration complete: " + result.describe());
+                System.out.println();
+                System.out.println("Now point the partnerships component in config.xml at the database by replacing the");
+                System.out.println("XMLPartnershipFactory element with the commented DbPartnershipFactory example, then");
+                System.out.println("restart and check the partnership list matches the XML file it came from.");
+            }
+        } catch (OpenAS2Exception e) {
+            // A validation or state problem the operator can act on: the message is the useful part
+            System.err.println("Migration failed and nothing was written: " + e.getMessage());
+            System.exit(1);
+        } catch (Exception e) {
+            System.err.println("Migration failed unexpectedly and nothing was written: " + e.getMessage());
+            e.printStackTrace();
+            System.exit(1);
+        }
+    }
+}

--- a/Server/src/test/java/org/openas2/upgrades/MigratePartnershipsToDbTest.java
+++ b/Server/src/test/java/org/openas2/upgrades/MigratePartnershipsToDbTest.java
@@ -1,0 +1,395 @@
+package org.openas2.upgrades;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.File;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.StandardCopyOption;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.Statement;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.TreeMap;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.openas2.OpenAS2Exception;
+import org.openas2.TestUtils;
+import org.openas2.XMLSession;
+import org.openas2.partner.DbPartnershipFactory;
+import org.openas2.partner.Partnership;
+import org.openas2.util.Properties;
+
+/**
+ * Verifies that migrating a partnerships XML file into the database produces a database the
+ * DbPartnershipFactory loads into the same partnerships the XMLPartnershipFactory loaded from the
+ * file. The round trip against the shipped partnerships.xml is the test that matters most: a
+ * migration that silently drops an attribute or an override would break sending for that partner
+ * without any error.
+ */
+public class MigratePartnershipsToDbTest {
+
+    private static final Path SRC_CONFIG_DIR = Paths.get("src", "test", "resources", "config").toAbsolutePath();
+
+    private String connectString;
+    private Connection seedConn;
+    private File workDir;
+
+    @BeforeEach
+    public void setUp() throws Exception {
+        workDir = Files.createTempDirectory("migrate-partnerships").toFile();
+        connectString = "jdbc:h2:mem:migrate_partnerships_" + System.nanoTime() + ";DB_CLOSE_DELAY=-1";
+        seedConn = DriverManager.getConnection(connectString, "sa", "");
+        try (Statement s = seedConn.createStatement()) {
+            String ddl = new String(Files.readAllBytes(Paths.get("src", "config", "db_ddl.sql")), StandardCharsets.UTF_8);
+            for (String statement : ddl.split(";")) {
+                if (!statement.trim().isEmpty()) {
+                    s.execute(statement);
+                }
+            }
+        }
+    }
+
+    @AfterEach
+    public void tearDown() throws Exception {
+        if (seedConn != null) {
+            seedConn.close();
+        }
+        TestUtils.deleteDirectory(workDir);
+    }
+
+    @Test
+    public void migratedDatabaseLoadsTheSamePartnershipsAsTheXmlFile() throws Exception {
+        // Load the shipped config first: this is the reference result, and it also populates the
+        // static properties container that both factories use to resolve $properties.x$ placeholders
+        Map<String, Partnership> fromXml = loadPartnershipsFromXmlConfig();
+
+        MigratePartnershipsToDb migrator = new MigratePartnershipsToDb();
+        migrator.parse(new File(workDir, "partnerships.xml"));
+        MigratePartnershipsToDb.Result result = migrator.write(seedConn, false);
+
+        assertTrue(result.getPartners() > 0, "the shipped file defines partners");
+        assertTrue(result.getPartnerships() > 0, "the shipped file defines partnerships");
+
+        Map<String, Partnership> fromDb = loadPartnershipsFromDb();
+
+        assertEquals(fromXml.keySet(), fromDb.keySet(), "the same partnerships must load from the database");
+        for (Map.Entry<String, Partnership> entry : fromXml.entrySet()) {
+            Partnership xml = entry.getValue();
+            Partnership db = fromDb.get(entry.getKey());
+            String where = " for partnership " + entry.getKey();
+            assertEquals(sorted(xml.getSenderIDs()), sorted(db.getSenderIDs()), "sender IDs differ" + where);
+            assertEquals(sorted(xml.getReceiverIDs()), sorted(db.getReceiverIDs()), "receiver IDs differ" + where);
+            assertEquals(sorted(xml.getAttributes()), sortedWithoutPollerConfig(db.getAttributes()),
+                    "attributes differ" + where);
+        }
+    }
+
+    @Test
+    public void senderAndReceiverOverridesBecomeCategorisedRows() throws Exception {
+        File xml = writePartnershipsXml(""
+                + "<partner name='CompanyA' as2_id='A_OID' x509_alias='companya'/>"
+                + "<partner name='CompanyB' as2_id='B_OID' x509_alias='companyb'/>"
+                + "<partnership name='A-to-B'>"
+                + "  <sender name='CompanyA' x509_alias='companya_signing'/>"
+                + "  <receiver name='CompanyB' as2_id='B_OID_ALT'/>"
+                + "  <attribute name='protocol' value='as2'/>"
+                + "</partnership>");
+
+        MigratePartnershipsToDb migrator = new MigratePartnershipsToDb();
+        migrator.parse(xml);
+        MigratePartnershipsToDb.Result result = migrator.write(seedConn, false);
+
+        assertEquals(1, result.getSenderOverrides());
+        assertEquals(1, result.getReceiverOverrides());
+        assertEquals("companya_signing", attributeValue("A-to-B", DbPartnershipFactory.CATEGORY_SENDER, "x509_alias"));
+        assertEquals("B_OID_ALT", attributeValue("A-to-B", DbPartnershipFactory.CATEGORY_RECEIVER, "as2_id"));
+        assertEquals("as2", attributeValue("A-to-B", DbPartnershipFactory.CATEGORY_ATTRIBUTE, "protocol"));
+        // The name identifies the partner row and must not be duplicated as an override
+        assertEquals(null, attributeValue("A-to-B", DbPartnershipFactory.CATEGORY_SENDER, "name"));
+    }
+
+    @Test
+    public void pollerConfigBecomesPollerConfigRows() throws Exception {
+        File xml = writePartnershipsXml(""
+                + "<partner name='CompanyA' as2_id='A_OID'/>"
+                + "<partner name='CompanyB' as2_id='B_OID'/>"
+                + "<partnership name='A-to-B'>"
+                + "  <sender name='CompanyA'/><receiver name='CompanyB'/>"
+                + "  <pollerConfig enabled='true' interval='10'/>"
+                + "</partnership>");
+
+        MigratePartnershipsToDb migrator = new MigratePartnershipsToDb();
+        migrator.parse(xml);
+        assertEquals(2, migrator.write(seedConn, false).getPollerConfigAttributes());
+
+        assertEquals("true", attributeValue("A-to-B", DbPartnershipFactory.CATEGORY_POLLER_CONFIG, "enabled"));
+        assertEquals("10", attributeValue("A-to-B", DbPartnershipFactory.CATEGORY_POLLER_CONFIG, "interval"));
+    }
+
+    @Test
+    public void placeholdersAreStoredUnresolved() throws Exception {
+        // Both factories resolve these when loading, so resolving them here would freeze a value
+        // that is meant to follow the configuration
+        File xml = writePartnershipsXml(""
+                + "<partner name='CompanyA' as2_id='A_OID'/>"
+                + "<partner name='CompanyB' as2_id='B_OID'/>"
+                + "<partnership name='A-to-B'>"
+                + "  <sender name='CompanyA'/><receiver name='CompanyB'/>"
+                + "  <attribute name='as2_url' value='http://localhost:$properties.port$/HttpReceiver'/>"
+                + "</partnership>");
+
+        MigratePartnershipsToDb migrator = new MigratePartnershipsToDb();
+        migrator.parse(xml);
+        migrator.write(seedConn, false);
+
+        assertEquals("http://localhost:$properties.port$/HttpReceiver",
+                attributeValue("A-to-B", DbPartnershipFactory.CATEGORY_ATTRIBUTE, "as2_url"));
+    }
+
+    @Test
+    public void partnerNameIsNotDuplicatedAsAnAttributeRow() throws Exception {
+        File xml = writePartnershipsXml(""
+                + "<partner name='CompanyA' as2_id='A_OID' email='a@example.com'/>"
+                + "<partner name='CompanyB' as2_id='B_OID'/>"
+                + "<partnership name='A-to-B'><sender name='CompanyA'/><receiver name='CompanyB'/></partnership>");
+
+        MigratePartnershipsToDb migrator = new MigratePartnershipsToDb();
+        migrator.parse(xml);
+        migrator.write(seedConn, false);
+
+        // CompanyA contributes as2_id and email, CompanyB contributes as2_id: the names live in
+        // the partner rows themselves
+        assertEquals(3, countRows("partner_attribute"));
+        try (PreparedStatement s = seedConn.prepareStatement(
+                "SELECT COUNT(*) FROM partner_attribute WHERE ATTRIBUTE_NAME = 'name'");
+             ResultSet rs = s.executeQuery()) {
+            rs.next();
+            assertEquals(0, rs.getLong(1), "the partner name must not be written as an attribute row");
+        }
+    }
+
+    @Test
+    public void abortsWhenTheTablesAlreadyHoldData() throws Exception {
+        File xml = minimalXml();
+
+        MigratePartnershipsToDb first = new MigratePartnershipsToDb();
+        first.parse(xml);
+        first.write(seedConn, false);
+
+        MigratePartnershipsToDb second = new MigratePartnershipsToDb();
+        second.parse(xml);
+        OpenAS2Exception e = assertThrows(OpenAS2Exception.class, () -> second.write(seedConn, false));
+        assertTrue(e.getMessage().contains("already contains"), e.getMessage());
+        // The failed run must not have added anything on top of the first
+        assertEquals(2, countRows("partner"));
+        assertEquals(1, countRows("partnership"));
+    }
+
+    @Test
+    public void replaceClearsTheExistingRowsFirst() throws Exception {
+        MigratePartnershipsToDb first = new MigratePartnershipsToDb();
+        first.parse(minimalXml());
+        first.write(seedConn, false);
+
+        File different = writePartnershipsXml(""
+                + "<partner name='CompanyC' as2_id='C_OID'/>"
+                + "<partner name='CompanyD' as2_id='D_OID'/>"
+                + "<partnership name='C-to-D'><sender name='CompanyC'/><receiver name='CompanyD'/></partnership>",
+                "other-partnerships.xml");
+        MigratePartnershipsToDb second = new MigratePartnershipsToDb();
+        second.parse(different);
+        second.write(seedConn, true);
+
+        assertEquals(2, countRows("partner"));
+        assertEquals(1, countRows("partnership"));
+        assertNotNull(findPartnershipId("C-to-D"), "the replacement partnership must be present");
+        assertEquals(null, findPartnershipId("A-to-B"), "the replaced partnership must be gone");
+    }
+
+    @Test
+    public void unknownSenderPartnerIsRejectedBeforeAnythingIsWritten() throws Exception {
+        File xml = writePartnershipsXml(""
+                + "<partner name='CompanyA' as2_id='A_OID'/>"
+                + "<partnership name='A-to-Ghost'><sender name='CompanyA'/><receiver name='NoSuchPartner'/></partnership>");
+
+        MigratePartnershipsToDb migrator = new MigratePartnershipsToDb();
+        OpenAS2Exception e = assertThrows(OpenAS2Exception.class, () -> migrator.parse(xml));
+        assertTrue(e.getMessage().contains("undefined receiver"), e.getMessage());
+        assertEquals(0, countRows("partner"), "validation happens before any write");
+    }
+
+    @Test
+    public void senderWithoutAPartnerNameIsRejectedWithAnActionableMessage() throws Exception {
+        // Valid in the XML file (the IDs can be inline) but unrepresentable in the schema, which
+        // requires every partnership to point at a partner row
+        File xml = writePartnershipsXml(""
+                + "<partner name='CompanyB' as2_id='B_OID'/>"
+                + "<partnership name='Inline-to-B'><sender as2_id='INLINE_OID'/><receiver name='CompanyB'/></partnership>");
+
+        MigratePartnershipsToDb migrator = new MigratePartnershipsToDb();
+        OpenAS2Exception e = assertThrows(OpenAS2Exception.class, () -> migrator.parse(xml));
+        assertTrue(e.getMessage().contains("has no sender element naming a partner"), e.getMessage());
+        assertTrue(e.getMessage().contains("re-run"), "the message should say what to do: " + e.getMessage());
+    }
+
+    @Test
+    public void duplicateDefinitionsAreRejected() throws Exception {
+        File dupPartner = writePartnershipsXml(""
+                + "<partner name='CompanyA' as2_id='A_OID'/>"
+                + "<partner name='CompanyA' as2_id='A_OID_2'/>", "dup-partner.xml");
+        assertTrue(assertThrows(OpenAS2Exception.class, () -> new MigratePartnershipsToDb().parse(dupPartner))
+                .getMessage().contains("Partner is defined more than once"));
+
+        File dupPartnership = writePartnershipsXml(""
+                + "<partner name='CompanyA' as2_id='A_OID'/>"
+                + "<partner name='CompanyB' as2_id='B_OID'/>"
+                + "<partnership name='A-to-B'><sender name='CompanyA'/><receiver name='CompanyB'/></partnership>"
+                + "<partnership name='A-to-B'><sender name='CompanyB'/><receiver name='CompanyA'/></partnership>",
+                "dup-partnership.xml");
+        assertTrue(assertThrows(OpenAS2Exception.class, () -> new MigratePartnershipsToDb().parse(dupPartnership))
+                .getMessage().contains("Partnership is defined more than once"));
+    }
+
+    @Test
+    public void overlongAttributeValueIsRejectedRatherThanTruncated() throws Exception {
+        StringBuilder tooLong = new StringBuilder();
+        for (int i = 0; i < 4001; i++) {
+            tooLong.append('x');
+        }
+        File xml = writePartnershipsXml(""
+                + "<partner name='CompanyA' as2_id='A_OID'/>"
+                + "<partner name='CompanyB' as2_id='B_OID'/>"
+                + "<partnership name='A-to-B'><sender name='CompanyA'/><receiver name='CompanyB'/>"
+                + "  <attribute name='subject' value='" + tooLong + "'/>"
+                + "</partnership>");
+
+        OpenAS2Exception e = assertThrows(OpenAS2Exception.class, () -> new MigratePartnershipsToDb().parse(xml));
+        assertTrue(e.getMessage().contains("exceeds the 4000 character"), e.getMessage());
+    }
+
+    /* ------------------------------------------------------------------ helpers */
+
+    /**
+     * Copies the shipped config to a temp dir, loads it with an XMLSession and returns the
+     * partnerships the XML factory produced, keyed by name.
+     */
+    private Map<String, Partnership> loadPartnershipsFromXmlConfig() throws Exception {
+        for (String f : SRC_CONFIG_DIR.toFile().list()) {
+            Files.copy(SRC_CONFIG_DIR.resolve(f), workDir.toPath().resolve(f), StandardCopyOption.REPLACE_EXISTING);
+        }
+        System.clearProperty(Properties.OPENAS2_PROPERTIES_FILE_PROP);
+        XMLSession session = new XMLSession(workDir.getAbsolutePath() + File.separator + "config.xml");
+        try {
+            return byName(session.getPartnershipFactory().getPartnerships());
+        } finally {
+            session.stop();
+        }
+    }
+
+    /** Loads the migrated database through the real factory, keyed by name. */
+    private Map<String, Partnership> loadPartnershipsFromDb() throws Exception {
+        DbPartnershipFactory factory = new DbPartnershipFactory();
+        Map<String, String> params = new HashMap<String, String>();
+        params.put(DbPartnershipFactory.PARAM_USE_EMBEDDED_DB, "true");
+        params.put("tcp_server_start", "false");
+        params.put(DbPartnershipFactory.PARAM_DB_USER, "sa");
+        params.put(DbPartnershipFactory.PARAM_DB_PWD, "");
+        params.put(DbPartnershipFactory.PARAM_JDBC_CONNECT_STRING, connectString);
+        // A null session means no partnership poller is launched, which is all this test needs
+        factory.init(null, params);
+        try {
+            return byName(factory.getPartnerships());
+        } finally {
+            factory.destroy();
+        }
+    }
+
+    private Map<String, Partnership> byName(List<Partnership> list) {
+        Map<String, Partnership> map = new LinkedHashMap<String, Partnership>();
+        for (Partnership p : list) {
+            map.put(p.getName(), p);
+        }
+        return map;
+    }
+
+    private <V> Map<String, V> sorted(Map<String, V> map) {
+        return new TreeMap<String, V>(map);
+    }
+
+    /**
+     * The database factory also copies the poller config into the partnership attributes prefixed
+     * with "pollerConfig." so the view command can render it. The XML factory does that at view
+     * time instead, so those keys are dropped before comparing the two.
+     */
+    private Map<String, String> sortedWithoutPollerConfig(Map<String, String> map) {
+        Map<String, String> filtered = new TreeMap<String, String>();
+        for (Map.Entry<String, String> entry : map.entrySet()) {
+            if (!entry.getKey().startsWith(Partnership.PCFG_POLLER + ".")) {
+                filtered.put(entry.getKey(), entry.getValue());
+            }
+        }
+        return filtered;
+    }
+
+    private File minimalXml() throws Exception {
+        return writePartnershipsXml(""
+                + "<partner name='CompanyA' as2_id='A_OID'/>"
+                + "<partner name='CompanyB' as2_id='B_OID'/>"
+                + "<partnership name='A-to-B'><sender name='CompanyA'/><receiver name='CompanyB'/></partnership>");
+    }
+
+    private File writePartnershipsXml(String body) throws Exception {
+        return writePartnershipsXml(body, "partnerships.xml");
+    }
+
+    private File writePartnershipsXml(String body, String fileName) throws Exception {
+        String xml = "<?xml version=\"1.0\" encoding=\"UTF-8\"?><partnerships>"
+                + body.replace('\'', '"') + "</partnerships>";
+        File f = new File(workDir, fileName);
+        Files.write(f.toPath(), xml.getBytes(StandardCharsets.UTF_8));
+        return f;
+    }
+
+    private long countRows(String table) throws Exception {
+        try (PreparedStatement s = seedConn.prepareStatement("SELECT COUNT(*) FROM " + table);
+             ResultSet rs = s.executeQuery()) {
+            rs.next();
+            return rs.getLong(1);
+        }
+    }
+
+    private Long findPartnershipId(String name) throws Exception {
+        try (PreparedStatement s = seedConn.prepareStatement("SELECT ID FROM partnership WHERE NAME = ?")) {
+            s.setString(1, name);
+            try (ResultSet rs = s.executeQuery()) {
+                return rs.next() ? rs.getLong(1) : null;
+            }
+        }
+    }
+
+    private String attributeValue(String partnershipName, String category, String attributeName) throws Exception {
+        try (PreparedStatement s = seedConn.prepareStatement(
+                "SELECT pa.ATTRIBUTE_VALUE FROM partnership_attribute pa JOIN partnership p ON p.ID = pa.PARTNERSHIP_ID"
+                        + " WHERE p.NAME = ? AND pa.CATEGORY = ? AND pa.ATTRIBUTE_NAME = ?")) {
+            s.setString(1, partnershipName);
+            s.setString(2, category);
+            s.setString(3, attributeName);
+            try (ResultSet rs = s.executeQuery()) {
+                return rs.next() ? rs.getString(1) : null;
+            }
+        }
+    }
+}

--- a/changes.txt
+++ b/changes.txt
@@ -1,5 +1,17 @@
 **IMPORTANT NOTE**: Please review upgrade notes in the RELEASE-NOTES.md if you are upgrading
 
+Version UNRELEASED
+===========================
+
+This is a minor enhancement release.
+1. Add a migration tool that loads a partnerships XML file into the partner and partnership database tables read by
+   DbPartnershipFactory, so an existing XML configuration can be moved to the database store without being retyped:
+   bin/upgrade/migrate_partnerships_to_db.sh <partnerships.xml> <jdbc_url> <db_user> <db_password>. Sender and receiver
+   overrides and pollerConfig entries are carried across as their respective attribute categories, and values are stored
+   unresolved so placeholders such as $properties.storageBaseDir$ keep working. Pass --dry-run to validate the file and
+   see what would be written without touching the database, or --replace to overwrite partnerships already stored there.
+   The whole migration runs in one transaction, so a file that cannot be represented in the schema leaves it untouched.
+
 Version 4.11.0 - 2026-09-02
 ===========================
 


### PR DESCRIPTION
`DbPartnershipFactory` can read partnerships from the database instead of the XML file, but there was no way to get an existing configuration in there short of retyping it. This adds a migration tool.

```
bin/upgrade/migrate_partnerships_to_db.sh <partnerships.xml> <jdbc_url> <db_user> <db_password>
bin/upgrade/migrate_partnerships_to_db.sh <partnerships.xml> --dry-run
```

`org.openas2.upgrades.MigratePartnershipsToDb` plus a wrapper script, following the existing `MigratePollingModuleConfig` / `config_transform.sh` convention.

## Mapping

Derived from what each factory does on load, so the migrated database is equivalent rather than approximately right:

| XML | Database |
|---|---|
| `<partner name="X" a="1"/>` | `partner(NAME='X')` plus `partner_attribute` rows, excluding `name` since `loadPartners` synthesises it from the row |
| `<sender name="A"/>` | `partnership.SENDER_PARTNER_ID` resolves to A's row |
| `<sender name="A" x509_alias="z"/>` | plus `partnership_attribute(CATEGORY='sender', ...)` for the override |
| `<attribute name= value=/>` | `CATEGORY='attribute'` |
| `<pollerConfig .../>` | `CATEGORY='pollerConfig'` |

## Notable decisions

- **Values are stored unresolved.** Both factories run `attributeEnhancer` when they load, so resolving `$properties.storageBaseDir$` at migration time would freeze a value meant to stay dynamic. The shipped file's `subject=File $attributes.filename$ sent from $sender.name$...` has to survive verbatim; there is a test for it.
- **One transaction, and the whole file is validated before anything is written**, so a file the schema cannot represent leaves the database untouched.
- **It refuses to run against populated tables**, since that would silently merge two configurations. `--replace` is required to overwrite.
- **`--dry-run`** parses, validates and reports what would be written without connecting to write.

## One case that cannot be migrated

A partnership whose `sender`/`receiver` element carries inline IDs instead of naming a partner is valid in the XML file but unrepresentable in the schema, which requires every partnership to reference a partner row. Rather than inventing a partner, the tool aborts naming the partnership and what to change. `--dry-run` surfaces these before any write.

## Testing

144 tests pass, 11 new. The main one migrates the shipped `partnerships.xml`, loads it back through the real `DbPartnershipFactory`, and asserts it produces the same partnerships `XMLPartnershipFactory` produced from the file, comparing sender IDs, receiver IDs and every attribute, so a dropped attribute or override cannot pass unnoticed. Also verified end to end from the CLI against an H2 file database, including the abort-on-populated and `--replace` paths.

Note that `config/db_ddl.sql` drops `msg_metadata`, so only the partner and partnership section should be run to create the tables. The usage text and wrapper both warn about this.